### PR TITLE
Check to see if local file exists before opening

### DIFF
--- a/spec/suite_helper.rb
+++ b/spec/suite_helper.rb
@@ -25,7 +25,9 @@ module RDF::Util
       when /^#{REMOTE_PATH}/
         begin
           #puts "attempt to open #{filename_or_url} locally"
-          if response = ::File.open(filename_or_url.to_s.sub(REMOTE_PATH, LOCAL_PATH))
+          local_filename = filename_or_url.to_s.sub(REMOTE_PATH, LOCAL_PATH)
+          if ::File.exist?(local_filename)
+            response = ::File.open(local_filename)
             #puts "use #{filename_or_url} locally"
             case filename_or_url.to_s
             when /\.jsonld$/


### PR DESCRIPTION
The `RDF::Util::File.open_file` method was throwing an exception when the local file did not exist. This modification will check to see if it exists, avoiding the exception and allowing open-uri to download the file.

I'm also getting errors when running the specs. Many of them look like formatting problems, EX:

```
40) JSON::LD test suite toRdf toRdf-0026-in.jsonld: Test creation of multiple types
Failure/Error: quads.sort.join("").should produce(sorted_expected, t.debug)
  Expected: _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
  _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .

  Actual  : _:t0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
  _:t0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
```
