### PR TITLE
Performance fixes

### DIFF
--- a/.fasterer.yml
+++ b/.fasterer.yml
@@ -1,0 +1,24 @@
+speedups:
+  parallel_assignment: false
+  rescue_vs_respond_to: true
+  module_eval: true
+  shuffle_first_vs_sample: true
+  for_loop_vs_each: true
+  each_with_index_vs_while: false
+  map_flatten_vs_flat_map: true
+  reverse_each_vs_reverse_each: true
+  select_first_vs_detect: true
+  sort_vs_sort_by: true
+  fetch_with_argument_vs_block: true
+  keys_each_vs_each_key: true
+  hash_merge_bang_vs_hash_brackets: true
+  block_vs_symbol_to_proc: true
+  proc_call_vs_yield: true
+  gsub_vs_tr: true
+  select_last_vs_reverse_detect: true
+  getter_vs_attr_reader: false
+  setter_vs_attr_writer: false
+
+exclude_paths:
+  - 'vendor/**/*.rb'
+  - 'spec/**/*.rb'

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 /spec.pdf
 /pkg/
 /.rbx/
+/.bundle/
 Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'jsonlint',         git: "git://github.com/dougbarth/jsonlint.git", platform
 group :development do
   gem 'rdf-turtle',     git: "git://github.com/ruby-rdf/rdf-turtle.git", branch: "develop"
   gem 'rdf-trig',       git: "git://github.com/ruby-rdf/rdf-trig.git", branch: "develop"
+  gem 'fasterer'
 end
 
 group :development, :test do

--- a/lib/json/ld/api.rb
+++ b/lib/json/ld/api.rb
@@ -87,7 +87,7 @@ module JSON::LD
     # @yieldparam [API]
     # @raise [JsonLdError]
     def initialize(input, context, options = {}, &block)
-      @options = {compactArrays: true, rename_bnodes: true}.merge(options)
+      @options = {compactArrays: true, rename_bnodes: true}.merge!(options)
       @options[:validate] = true if @options[:processingMode] == "json-ld-1.0"
       @options[:documentLoader] ||= self.class.method(:documentLoader)
       @namer = options[:unique_bnodes] ? BlankNodeUniqer.new : (@options[:rename_bnodes] ? BlankNodeNamer.new("b") : BlankNodeMapper.new)
@@ -98,7 +98,7 @@ module JSON::LD
       @value = case input
       when Array, Hash then input.dup
       when IO, StringIO
-        @options = {base: input.base_uri}.merge(@options) if input.respond_to?(:base_uri)
+        @options = {base: input.base_uri}.merge!(@options) if input.respond_to?(:base_uri)
 
         # if input impelements #links, attempt to get a contextUrl from that link
         content_type = input.respond_to?(:content_type) ? input.content_type : "application/json"
@@ -113,7 +113,7 @@ module JSON::LD
       when String
         remote_doc = @options[:documentLoader].call(input, @options)
 
-        @options = {base: remote_doc.documentUrl}.merge(@options)
+        @options = {base: remote_doc.documentUrl}.merge!(@options)
         context_ref = remote_doc.contextUrl
 
         case remote_doc.document
@@ -322,7 +322,7 @@ module JSON::LD
         requireAll:     true,
         omitDefault:    false,
         documentLoader: method(:documentLoader)
-      }.merge(options)
+      }.merge!(options)
 
       framing_state = {
         graphs:       {'@default' => {}, '@merged' => {}},
@@ -471,7 +471,7 @@ module JSON::LD
     # @return [Object, Hash]
     #   If a block is given, the result of evaluating the block is returned, otherwise, the expanded JSON-LD document
     def self.fromRdf(input, options = {}, &block)
-      options = {useNativeTypes: false}.merge(options)
+      options = {useNativeTypes: false}.merge!(options)
       result = nil
 
       API.new(nil, nil, options) do |api|

--- a/lib/json/ld/compact.rb
+++ b/lib/json/ld/compact.rb
@@ -46,7 +46,7 @@ module JSON::LD
         inside_reverse = property == '@reverse'
         result = {}
 
-        element.keys.each do |expanded_property|
+        element.each_key do |expanded_property|
           expanded_value = element[expanded_property]
           debug("") {"#{expanded_property}: #{expanded_value.inspect}"}
 

--- a/lib/json/ld/context.rb
+++ b/lib/json/ld/context.rb
@@ -990,7 +990,7 @@ module JSON::LD
     # @raise [RDF::ReaderError] if the iri cannot be expanded
     # @see http://json-ld.org/spec/latest/json-ld-api/#value-expansion
     def expand_value(property, value, options = {})
-      options = {useNativeTypes: false}.merge(options)
+      options = {useNativeTypes: false}.merge!(options)
       depth(options) do
         debug("expand_value") {"property: #{property.inspect}, value: #{value.inspect}"}
 

--- a/lib/json/ld/context.rb
+++ b/lib/json/ld/context.rb
@@ -337,7 +337,7 @@ module JSON::LD
             defined = {}
           # For each key-value pair in context invoke the Create Term Definition subalgorithm, passing result for active context, context for local context, key, and defined
             depth do
-              context.keys.each do |key|
+              context.each_key do |key|
                 result.create_term_definition(context, key, defined)
               end
             end

--- a/lib/json/ld/expand.rb
+++ b/lib/json/ld/expand.rb
@@ -15,7 +15,7 @@ module JSON::LD
     #   Ensure output objects have keys ordered properly
     # @return [Array, Hash]
     def expand(input, active_property, context, options = {})
-      options = {ordered: true}.merge(options)
+      options = {ordered: true}.merge!(options)
       debug("expand") {"input: #{input.inspect}, active_property: #{active_property.inspect}, context: #{context.inspect}"}
       result = case input
       when Array

--- a/lib/json/ld/resource.rb
+++ b/lib/json/ld/resource.rb
@@ -174,7 +174,7 @@ module JSON::LD
               stub: true
               )
           else
-            obj.keys.each do |k|
+            obj.each_key do |k|
               obj[k] = update_obj(obj[k], reference_map)
             end
             obj

--- a/lib/json/ld/utils.rb
+++ b/lib/json/ld/utils.rb
@@ -211,14 +211,13 @@ module JSON::LD
     # Add debug event to debug array, if specified
     #
     #   param [String] message
-    #   yieldreturn [String] appended to message, to allow for lazy-evaulation of message
+    #   yieldreturn [String] appended to message, to allow for lazy-evaluation of message
     def debug(*args)
-      options = args.last.is_a?(Hash) ? args.pop : {}
       return unless ::JSON::LD.debug? || @options[:debug]
-      depth = options[:depth] || @depth || 0
+      depth = @depth || 0
       list = args
       list << yield if block_given?
-      message = " " * depth * 2 + (list.empty? ? "" : list.join(": "))
+      message = " " * depth * 2 + list.join(": ")
       case @options[:debug]
       when Array
         @options[:debug] << message

--- a/lib/json/ld/utils.rb
+++ b/lib/json/ld/utils.rb
@@ -118,7 +118,7 @@ module JSON::LD
     #   true to allow duplicates, false not to (uses
     #     a simple shallow comparison of subject ID or value).
     def add_value(subject, property, value, options = {})
-      options = {property_is_array: false, allow_duplicate: true}.merge(options)
+      options = {property_is_array: false, allow_duplicate: true}.merge!(options)
 
       if value.is_a?(Array)
         subject[property] = [] if value.empty? && options[:property_is_array]

--- a/lib/json/ld/utils.rb
+++ b/lib/json/ld/utils.rb
@@ -9,7 +9,7 @@ module JSON::LD
     # @return [Boolean]
     def node?(value)
       value.is_a?(Hash) &&
-        (value.keys & %w(@value @list @set)).empty? &&
+        !(value.has_key?('@value') || value.has_key?('@list') || value.has_key?('@set')) &&
         (value.length > 1 || !value.has_key?('@id'))
     end
 


### PR DESCRIPTION
This PR contains several small performance fixes for json-ld.

The optimizations consist in:
 - applying recommendation of 'fasterer' gem (here `Hash#each_key` faster than `Hash#keys.each`)
 - removal of unused code in `JSON::LD::Utils#debug` that was executed even when debug is not on
 - refactoring expensive Array intersection in `JSON::LD::Utils.node?` for several `Hash#has_key?` calls
 - reduce allocation of Hashes by using `Hash#merge!` instead of `Hash#merge` when appropriate and safe

The specs still pass after all these changes.