### PR TITLE
Removed default value from hash initialization.

### DIFF
--- a/lib/json/ld/frame.rb
+++ b/lib/json/ld/frame.rb
@@ -157,7 +157,7 @@ module JSON::LD
           # If, after replacement, an array contains only the value null remove the value, leaving an empty array.
           input.map {|o| cleanup_preserve(o)}.compact
         when Hash
-          output = Hash.new(input.size)
+          output = Hash.new
           input.each do |key, value|
             if key == '@preserve'
               # replace all key-value pairs where the key is @preserve with the value from the key-pair


### PR DESCRIPTION
When trying to read a non-existent key from a hash generated by framing a JSON-LD document, the returned value isn't `nil`, but rather an integer.  

This appears to be because there is an issue with the initialization of the output hash—it's being passed a default value of the input size, rather than relying on Hash's *default* default value of nil.  (That's a sentence for you, eh?)

Removing this does not appear to cause any problems, and will resolve the issue. 

Below is a failing example, that stops failing with the supplied pull request.  (I apologize for not adding a test for it, but I couldn't figure out the most appropriate place to put the test.)

Thanks!

```ruby

require 'rdf/turtle'
require 'json/ld'

input = RDF::Graph.new << RDF::Turtle::Reader.new(%(
  @prefix foaf: <http://xmlns.com/foaf/0.1/> .

  <http://manu.sporny.org/#me> a foaf:Person;
     foaf:knows [ a foaf:Person;
       foaf:name "Gregg Kellogg"];
     foaf:name "Manu Sporny" .
))

context = JSON.parse "{}"

framed = nil
JSON::LD::API::fromRdf(input) do |expanded|
  framed = JSON::LD::API.frame(expanded, context)
end
data =  framed["@graph"].first
puts data["missing_value"] # Expected nil, actually 1

```