### PR TITLE
Performance fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development, :test do
   gem 'coveralls',  require: false, platform: :mri
   gem 'psych',      platforms: [:mri, :rbx]
   gem 'benchmark-ips'
+  gem 'rake'
 end
 
 group :debug do

--- a/lib/json/ld.rb
+++ b/lib/json/ld.rb
@@ -3,6 +3,7 @@
 $:.unshift(File.expand_path("../ld", __FILE__))
 require 'rdf' # @see http://rubygems.org/gems/rdf
 require 'multi_json'
+require 'set'
 
 module JSON
   ##
@@ -41,7 +42,7 @@ module JSON
       RDF.type.to_s => {"@type" => "@id"}
     }.freeze
 
-    KEYWORDS = %w(
+    KEYWORDS = Set.new(%w(
       @base
       @container
       @context
@@ -62,7 +63,7 @@ module JSON
       @value
       @version
       @vocab
-    ).freeze
+    )).freeze
 
     # Regexp matching an NCName.
     NC_REGEXP = Regexp.new(

--- a/lib/json/ld/api.rb
+++ b/lib/json/ld/api.rb
@@ -277,7 +277,9 @@ module JSON::LD
         create_node_map(value, graph_maps)
 
         default_graph = graph_maps['@default']
-        graph_maps.keys.kw_sort.reject {|k| k == '@default'}.each do |graph_name|
+        graph_maps.keys.kw_sort.each do |graph_name|
+          next if graph_name == '@default'
+
           graph = graph_maps[graph_name]
           entry = default_graph[graph_name] ||= {'@id' => graph_name}
           nodes = entry['@graph'] ||= []

--- a/lib/json/ld/api.rb
+++ b/lib/json/ld/api.rb
@@ -174,7 +174,7 @@ module JSON::LD
       end
 
       # If, after the algorithm outlined above is run, the resulting element is an JSON object with just a @graph property, element is set to the value of @graph's value.
-      result = result['@graph'] if result.is_a?(Hash) && result.keys == %w(@graph)
+      result = result['@graph'] if result.is_a?(Hash) && result.length == 1 && result.key?('@graph')
 
       # Finally, if element is a JSON object, it is wrapped into an array.
       result = [result].compact unless result.is_a?(Array)

--- a/lib/json/ld/compact.rb
+++ b/lib/json/ld/compact.rb
@@ -218,7 +218,7 @@ module JSON::LD
         end
 
         # Re-order result keys
-        result.keys.kw_sort.inject({}) {|map, kk| map[kk] = result[kk]; map}
+        result.keys.kw_sort.each_with_object({}) {|kk, memo| memo[kk] = result[kk]}
       else
         # For other types, the compacted value is the element value
         #log_debug("compact") {element.class.to_s}

--- a/lib/json/ld/compact.rb
+++ b/lib/json/ld/compact.rb
@@ -125,7 +125,7 @@ module JSON::LD
             next
           end
 
-          if expanded_value == []
+          if expanded_value.empty?
             item_active_property =
               context.compact_iri(expanded_property,
                                   value: expanded_value,

--- a/lib/json/ld/compact.rb
+++ b/lib/json/ld/compact.rb
@@ -58,7 +58,7 @@ module JSON::LD
           expanded_value = element[expanded_property]
           #log_debug("") {"#{expanded_property}: #{expanded_value.inspect}"}
 
-          if %w(@id @type).include?(expanded_property)
+          if expanded_property == '@id' || expanded_property == '@type'
             compacted_value = [expanded_value].flatten.compact.map do |expanded_type|
               context.compact_iri(expanded_type, vocab: (expanded_property == '@type'), log_depth: @options[:log_depth])
             end
@@ -118,7 +118,7 @@ module JSON::LD
           end
 
           # Otherwise, if expanded property is @index, @value, or @language:
-          if %w(@index @value @language).include?(expanded_property)
+          if expanded_property == '@index' || expanded_property == '@value' || expanded_property == '@language'
             al = context.compact_iri(expanded_property, vocab: true, quiet: true)
             #log_debug(expanded_property) {"#{al} => #{expanded_value.inspect}"}
             result[al] = expanded_value
@@ -181,7 +181,7 @@ module JSON::LD
               end
             end
 
-            if %w(@language @index @id @type).include?(container)
+            if container == '@language' || container == '@index' || container == '@id' || container == '@type'
               map_object = nest_result[item_active_property] ||= {}
               compacted_item = case container
               when '@id'

--- a/lib/json/ld/compact.rb
+++ b/lib/json/ld/compact.rb
@@ -43,7 +43,7 @@ module JSON::LD
         # @null objects are used in framing
         return nil if element.has_key?('@null')
 
-        if element.keys.any? {|k| %w(@id @value).include?(k)}
+        if element.key?('@id') || element.key?('@value')
           result = context.compact_value(property, element, log_depth: @options[:log_depth])
           unless result.is_a?(Hash)
             #log_debug("") {"=> scalar result: #{result.inspect}"}

--- a/lib/json/ld/context.rb
+++ b/lib/json/ld/context.rb
@@ -1576,9 +1576,10 @@ module JSON::LD
     #
     # @return [Array<RDF::URI>]
     def mappings
-      term_definitions.inject({}) do |memo, (t,td)|
-        memo[t] = td ? td.id : nil
-        memo
+      {}.tap do |memo|
+        term_definitions.each_pair do |t,td|
+          memo[t] = td ? td.id : nil
+        end
       end
     end
 
@@ -1598,9 +1599,10 @@ module JSON::LD
     # @return [Array<String>]
     # @deprecated
     def languages
-      term_definitions.inject({}) do |memo, (t,td)|
-        memo[t] = td.language_mapping
-        memo
+      {}.tap do |memo|
+        term_definitions.each_pair do |t,td|
+          memo[t] = td.language_mapping
+        end
       end
     end
 

--- a/lib/json/ld/context.rb
+++ b/lib/json/ld/context.rb
@@ -113,7 +113,7 @@ module JSON::LD
       def container_mapping=(mapping)
         mapping = Array(mapping)
         if @as_set = mapping.include?('@set')
-          mapping -= %w(@set)
+          mapping.delete('@set')
         end
         @container_mapping = mapping.first
       end
@@ -1615,7 +1615,7 @@ module JSON::LD
       end
 
       val = Array(container)
-      val -= %w(@set) if has_set = val.include?('@set')
+      val.delete('@set') if has_set = val.include?('@set')
 
       raise JsonLdError::InvalidContainerMapping,
         "'@container' has more than one value other than @set" if val.length > 1

--- a/lib/json/ld/context.rb
+++ b/lib/json/ld/context.rb
@@ -615,7 +615,7 @@ module JSON::LD
 
         if value.has_key?('@reverse')
           raise JsonLdError::InvalidReverseProperty, "unexpected key in #{value.inspect} on term #{term.inspect}" if
-            value.keys.any? {|k| %w(@id @nest).include?(k)}
+            value.key?('@id') || value.key?('@nest')
           raise JsonLdError::InvalidIRIMapping, "expected value of @reverse to be a string: #{value['@reverse'].inspect} on term #{term.inspect}" unless
             value['@reverse'].is_a?(String)
 
@@ -1297,7 +1297,7 @@ module JSON::LD
     def compact_value(property, value, options = {})
       #log_debug("compact_value") {"property: #{property.inspect}, value: #{value.inspect}"}
 
-      num_members = value.keys.length
+      num_members = value.length
 
       num_members -= 1 if index?(value) && container(property) == '@index'
       if num_members > 2

--- a/lib/json/ld/context.rb
+++ b/lib/json/ld/context.rb
@@ -655,7 +655,7 @@ module JSON::LD
               (simple_term || ((processingMode || 'json-ld-1.0') == 'json-ld-1.0'))
         elsif term.include?(':')
           # If term is a compact IRI with a prefix that is a key in local context then a dependency has been found. Use this algorithm recursively passing active context, local context, the prefix as term, and defined.
-          prefix, suffix = term.split(':')
+          prefix, suffix = term.split(':', 2)
           create_term_definition(local_context, prefix, defined) if local_context.has_key?(prefix)
 
           definition.id = if td = term_definitions[prefix]
@@ -980,11 +980,13 @@ module JSON::LD
     #   IRI or String, if it's a keyword
     # @raise [JSON::LD::JsonLdError::InvalidIRIMapping] if the value cannot be expanded
     # @see http://json-ld.org/spec/latest/json-ld-api/#iri-expansion
-    def expand_iri(value, documentRelative: false, vocab: false, local_context: nil, defined: {}, quiet: false, **options)
+    def expand_iri(value, documentRelative: false, vocab: false, local_context: nil, defined: nil, quiet: false, **options)
       return value unless value.is_a?(String)
 
       return value if KEYWORDS.include?(value)
       #log_debug("expand_iri") {"value: #{value.inspect}"} unless quiet
+
+      defined = defined || {} # if we initialized in the keyword arg we would allocate {} at each invokation, even in the 2 (common) early returns above.
 
       # If local context is not null, it contains a key that equals value, and the value associated with the key that equals value in defined is not true, then invoke the Create Term Definition subalgorithm, passing active context, local context, value as term, and defined. This will ensure that a term definition is created for value in active context during Context Processing.
       if local_context && local_context.has_key?(value) && !defined[value]

--- a/lib/json/ld/context.rb
+++ b/lib/json/ld/context.rb
@@ -800,7 +800,7 @@ module JSON::LD
       # Add term definitions for each class and property not in vocab, and
       # for those properties having an object range
       statements.each do |subject, values|
-        types = values.select {|v| v.predicate == RDF.type}.map(&:object)
+        types = values.each_with_object([]) { |v, memo| memo << v.object if v.predicate == RDF.type }
         is_property = types.any? {|t| t.to_s.include?("Property")}
         
         term = subject.to_s.split(/[\/\#]/).last

--- a/lib/json/ld/context.rb
+++ b/lib/json/ld/context.rb
@@ -1003,7 +1003,7 @@ module JSON::LD
 
         # If prefix is underscore (_) or suffix begins with double-forward-slash (//), return value as it is already an absolute IRI or a blank node identifier.
         return RDF::Node.new(namer.get_sym(suffix)) if prefix == '_'
-        return RDF::URI(value) if suffix[0,2] == '//'
+        return RDF::URI(value) if suffix.start_with?('//')
 
         # If local context is not null, it contains a key that equals prefix, and the value associated with the key that equals prefix in defined is not true, invoke the Create Term Definition algorithm, passing active context, local context, prefix as term, and defined. This will ensure that a term definition is created for prefix in active context during Context Processing.
         if local_context && local_context.has_key?(prefix) && !defined[prefix]

--- a/lib/json/ld/expand.rb
+++ b/lib/json/ld/expand.rb
@@ -42,7 +42,6 @@ module JSON::LD
         end
 
         output_object = {}
-        keys = ordered ? input.keys.kw_sort : input.keys
 
         # See if keys mapping to @type have terms with a local context
         input.keys.select do |key|

--- a/lib/json/ld/expand.rb
+++ b/lib/json/ld/expand.rb
@@ -113,7 +113,7 @@ module JSON::LD
 
         # Re-order result keys if ordering
         if ordered
-          output_object.keys.kw_sort.inject({}) {|map, kk| map[kk] = output_object[kk]; map}
+          output_object.keys.kw_sort.each_with_object({}) {|kk, memo| memo[kk] = output_object[kk]}
         else
           output_object
         end

--- a/lib/json/ld/expand.rb
+++ b/lib/json/ld/expand.rb
@@ -24,7 +24,7 @@ module JSON::LD
       when Array
         # If element is an array,
         is_list = context.container(active_property) == '@list'
-        value = input.map do |v|
+        value = input.each_with_object([]) do |v, memo|
           # Initialize expanded item to the result of using this algorithm recursively, passing active context, active property, and item as element.
           v = expand(v, active_property, context, ordered: ordered)
 
@@ -32,8 +32,8 @@ module JSON::LD
           raise JsonLdError::ListOfLists,
                 "A list may not contain another list" if
                 is_list && (v.is_a?(Array) || list?(v))
-          v
-        end.flatten.compact
+          memo << v unless v.nil?
+        end
 
         value
       when Hash

--- a/lib/json/ld/expand.rb
+++ b/lib/json/ld/expand.rb
@@ -87,7 +87,7 @@ module JSON::LD
         elsif !output_object.fetch('@type', []).is_a?(Array)
           # Otherwise, if result contains the key @type and its associated value is not an array, set it to an array containing only the associated value.
           output_object['@type'] = [output_object['@type']]
-        elsif output_object.keys.any? {|k| %w(@set @list).include?(k)}
+        elsif output_object.key?('@set') || output_object.key?('@list')
           # Otherwise, if result contains the key @set or @list:
           # The result must contain at most one other key and that key must be @index. Otherwise, an invalid set or list object error has been detected and processing is aborted.
           raise JsonLdError::InvalidSetOrListObject,
@@ -95,15 +95,15 @@ module JSON::LD
                 (output_object.keys - %w(@set @list @index)).empty?
 
           # If result contains the key @set, then set result to the key's associated value.
-          return output_object['@set'] if output_object.keys.include?('@set')
+          return output_object['@set'] if output_object.key?('@set')
         end
 
         # If result contains only the key @language, set result to null.
-        return nil if output_object.keys == %w(@language)
+        return nil if output_object.length == 1 && output_object.key?('@language')
 
         # If active property is null or @graph, drop free-floating values as follows:
         if (active_property || '@graph') == '@graph' &&
-          (output_object.keys.any? {|k| %w(@value @list).include?(k)} ||
+          (output_object.key?('@value') || output_object.key?('@list') ||
            (output_object.keys - %w(@id)).empty? && !framing)
           #log_debug(" =>") { "empty top-level: " + output_object.inspect}
           return nil

--- a/lib/json/ld/expand.rb
+++ b/lib/json/ld/expand.rb
@@ -68,13 +68,14 @@ module JSON::LD
             "value object has unknown keys: #{output_object.inspect}"
           end
 
-          output_object.delete('@language') if Array(output_object['@language']).join('').to_s.empty?
-          output_object.delete('@type') if Array(output_object['@type']).join('').to_s.empty?
+          output_object.delete('@language') if output_object.key?('@language') && Array(output_object['@language']).empty?
+          output_object.delete('@type') if output_object.key?('@type') && Array(output_object['@type']).empty?
 
           # If the value of result's @value key is null, then set result to null.
-          return nil if Array(output_object['@value']).empty?
+          ary = Array(output_object['@value'])
+          return nil if ary.empty?
 
-          if !Array(output_object['@value']).all? {|v| v.is_a?(String) || v.is_a?(Hash) && v.empty?} && output_object.has_key?('@language')
+          if !ary.all? {|v| v.is_a?(String) || v.is_a?(Hash) && v.empty?} && output_object.has_key?('@language')
             # Otherwise, if the value of result's @value member is not a string and result contains the key @language, an invalid language-tagged value error has been detected (only strings can be language-tagged) and processing is aborted.
             raise JsonLdError::InvalidLanguageTaggedValue,
                   "when @language is used, @value must be a string: #{output_object.inspect}"

--- a/lib/json/ld/expand.rb
+++ b/lib/json/ld/expand.rb
@@ -44,10 +44,9 @@ module JSON::LD
         output_object = {}
 
         # See if keys mapping to @type have terms with a local context
-        input.keys.select do |key|
-          context.expand_iri(key, vocab: true) == '@type'
-        end.each do |key|
-          Array(input[key]).each do |term|
+        input.each_pair do |key, val|
+          next unless context.expand_iri(key, vocab: true) == '@type'
+          Array(val).each do |term|
             term_context = context.term_definitions[term].context if context.term_definitions[term]
             context = term_context ? context.parse(term_context) : context
           end
@@ -303,7 +302,7 @@ module JSON::LD
             end
 
             # If expanded value contains members other than @reverse:
-            unless value.keys.reject {|k| k == '@reverse'}.empty?
+            if !value.key?('@reverse') || value.length > 1
               # If result does not have an @reverse member, create one and set its value to an empty JSON object.
               reverse_map = output_object['@reverse'] ||= {}
               value.each do |property, items|

--- a/lib/json/ld/expand.rb
+++ b/lib/json/ld/expand.rb
@@ -62,7 +62,7 @@ module JSON::LD
         # If result contains the key @value:
         if value?(output_object)
           unless (output_object.keys - %w(@value @language @type @index)).empty? &&
-                 (output_object.keys & %w(@language @type)).length < 2
+                 !(output_object.key?('@language') && output_object.key?('@type'))
             # The result must not contain any keys other than @value, @language, @type, and @index. It must not contain both the @language key and the @type key. Otherwise, an invalid value object error has been detected and processing is aborted.
             raise JsonLdError::InvalidValueObject,
             "value object has unknown keys: #{output_object.inspect}"

--- a/lib/json/ld/expand.rb
+++ b/lib/json/ld/expand.rb
@@ -1,5 +1,7 @@
 # -*- encoding: utf-8 -*-
 # frozen_string_literal: true
+require 'set'
+
 module JSON::LD
   ##
   # Expand module, used as part of API
@@ -125,6 +127,8 @@ module JSON::LD
     end
 
   private
+    CONTAINER_MAPPING_INDEX_ID_TYPE = Set.new(%w(@index @id @type)).freeze
+
     # Expand each key and value of element adding them to result
     def expand_object(input, active_property, context, output_object, ordered: false)
       framing = @options[:processingMode].include?("expand-frame")
@@ -366,7 +370,7 @@ module JSON::LD
           end
 
           ary
-        elsif %w(@index @id @type).include?(container) && value.is_a?(Hash)
+        elsif CONTAINER_MAPPING_INDEX_ID_TYPE.include?(container) && value.is_a?(Hash)
           # Otherwise, if key's container mapping in active context is @index, @id, @type, an IRI or Blank Node and value is a JSON object then value is expanded from an index map as follows:
           
           # Set ary to an empty array.

--- a/lib/json/ld/extensions.rb
+++ b/lib/json/ld/extensions.rb
@@ -17,13 +17,14 @@ class Array
   # @yieldreturn [Integer]
   # @return [Array]
   KW_ORDER = %w(@base @id @value @type @language @vocab @container @graph @list @set @index).freeze
+  KW_ORDER_CACHE = KW_ORDER.each_with_object({}) do |kw, memo|
+    memo[kw] = "@#{KW_ORDER.index(kw)}"
+  end.freeze
 
   # Order, considering keywords to come before other strings
   def kw_sort
     self.sort do |a, b|
-      a = "@#{KW_ORDER.index(a)}" if KW_ORDER.include?(a)
-      b = "@#{KW_ORDER.index(b)}" if KW_ORDER.include?(b)
-      a <=> b
+      KW_ORDER_CACHE.fetch(a, a) <=> KW_ORDER_CACHE.fetch(b, b)
     end
   end
 

--- a/lib/json/ld/frame.rb
+++ b/lib/json/ld/frame.rb
@@ -264,10 +264,9 @@ module JSON::LD
     #
     # @return all of the matched subjects.
     def filter_subjects(state, subjects, frame, flags)
-      subjects.inject({}) do |memo, id|
+      subjects.each_with_object({}) do |id, memo|
         subject = state[:graphMap][state[:graph]][id]
         memo[id] = subject if filter_subject(subject, frame, state, flags)
-        memo
       end
     end
 

--- a/lib/json/ld/frame.rb
+++ b/lib/json/ld/frame.rb
@@ -1,5 +1,7 @@
 # -*- encoding: utf-8 -*-
 # frozen_string_literal: true
+require 'set'
+
 module JSON::LD
   module Frame
     include Utils
@@ -96,7 +98,7 @@ module JSON::LD
             recurse, subframe = (state[:graph] != '@merged'), {}
           else
             subframe = frame['@graph'].first
-            recurse = !%w(@merged @default).include?(id)
+            recurse = !(id == '@merged' || id == '@default')
             subframe = {} unless subframe.is_a?(Hash)
           end
 
@@ -267,6 +269,8 @@ module JSON::LD
       end
     end
 
+    EXCLUDED_FRAMING_KEYWORDS = Set.new(%w(@default @embed @explicit @omitDefault @requireAll)).freeze
+
     ##
     # Returns true if the given node matches the given frame.
     #
@@ -320,7 +324,7 @@ module JSON::LD
             validate_frame(v)
             has_default = v.has_key?('@default')
             # Exclude framing keywords
-            v = v.dup.delete_if {|kk,vv| %w(@default @embed @explicit @omitDefault @requireAll).include?(kk)}
+            v = v.dup.delete_if {|kk,vv| EXCLUDED_FRAMING_KEYWORDS.include?(kk)}
           end
 
 

--- a/lib/json/ld/frame.rb
+++ b/lib/json/ld/frame.rb
@@ -191,21 +191,26 @@ module JSON::LD
     ##
     # Recursively find and count blankNode identifiers.
     # @return [Hash{String => Integer}]
-    def count_blank_node_identifiers(input, results = {})
-      case input
-      when Array
-        input.map {|o| count_blank_node_identifiers(o, results)}
-      when Hash
-        input.each do |k, v|
-          count_blank_node_identifiers(v, results)
-        end
-      when String
-        if input.start_with?('_:')
-          results[input] ||= 0
-          results[input] += 1
-        end
+    def count_blank_node_identifiers(input)
+      {}.tap do |results|
+        count_blank_node_identifiers_internal(input, results)
       end
-      results
+    end
+
+    def count_blank_node_identifiers_internal(input, results)
+      case input
+        when Array
+          input.each {|o| count_blank_node_identifiers_internal(o, results)}
+        when Hash
+          input.each do |k, v|
+            count_blank_node_identifiers_internal(v, results)
+          end
+        when String
+          if input.start_with?('_:')
+            results[input] ||= 0
+            results[input] += 1
+          end
+      end
     end
 
     ##

--- a/lib/json/ld/frame.rb
+++ b/lib/json/ld/frame.rb
@@ -154,7 +154,9 @@ module JSON::LD
         end
 
         # handle defaults in order
-        frame.keys.kw_sort.reject {|p| p.start_with?('@')}.each do |prop|
+        frame.keys.kw_sort.each do |prop|
+          next if prop.start_with?('@')
+
           # if omit default is off, then include default values for properties that appear in the next frame but are not in the matching subject
           n = frame[prop].first || {}
           omit_default_on = get_frame_flag(n, options, :omitDefault)

--- a/lib/json/ld/frame.rb
+++ b/lib/json/ld/frame.rb
@@ -520,8 +520,8 @@ module JSON::LD
       v2, t2, l2 = Array(pattern['@value']), Array(pattern['@type']), Array(pattern['@language'])
       return true if (v2 + t2 + l2).empty?
       return false unless v2.include?(v1) || v2 == [{}]
-      return false unless t2.include?(t1) || t1 && t2 == [{}] || t1.nil? && (t2 || []) == []
-      return false unless l2.include?(l1) || l1 && l2 == [{}] || l1.nil? && (l2 || []) == []
+      return false unless t2.include?(t1) || t1 && t2 == [{}] || t1.nil? && (t2 || []).empty?
+      return false unless l2.include?(l1) || l1 && l2 == [{}] || l1.nil? && (l2 || []).empty?
       true
     end
   end

--- a/lib/json/ld/frame.rb
+++ b/lib/json/ld/frame.rb
@@ -490,7 +490,11 @@ module JSON::LD
     # @param [Hash] flags the current framing flags.
     # @return [Array<Hash>] the implicit frame.
     def create_implicit_frame(flags)
-      flags.keys.inject({}) {|memo, key| memo["@#{key}"] = [flags[key]]; memo}
+      {}.tap do |memo|
+        flags.each_pair do |key, val|
+          memo["@#{key}"] = [val]
+        end
+      end
     end
 
   private

--- a/lib/json/ld/frame.rb
+++ b/lib/json/ld/frame.rb
@@ -325,7 +325,7 @@ module JSON::LD
             validate_frame(v)
             has_default = v.has_key?('@default')
             # Exclude framing keywords
-            v = v.dup.delete_if {|kk,vv| EXCLUDED_FRAMING_KEYWORDS.include?(kk)}
+            v = v.reject {|kk,vv| EXCLUDED_FRAMING_KEYWORDS.include?(kk)}
           end
 
 

--- a/lib/json/ld/resource.rb
+++ b/lib/json/ld/resource.rb
@@ -110,19 +110,19 @@ module JSON::LD
     # @return [Hash] deresolved attribute hash
     def deresolve
       node_definition = if resolved?
-        deresolved = attributes.keys.inject({}) do |memo, prop|
-          value = attributes[prop]
-          memo[prop] = case value
-          when Resource
-            {'id' => value.id}
-          when Array
-            value.map do |v|
-              v.is_a?(Resource) ? {'id' => v.id} : v
+        deresolved = [].tap do |memo|
+          attributes.each_pair do |prop, value|
+            memo[prop] = case value
+            when Resource
+              {'id' => value.id}
+            when Array
+              value.map do |v|
+                v.is_a?(Resource) ? {'id' => v.id} : v
+              end
+            else
+              value
             end
-          else
-            value
           end
-          memo
         end
         deresolved
       else

--- a/lib/json/ld/resource.rb
+++ b/lib/json/ld/resource.rb
@@ -88,7 +88,7 @@ module JSON::LD
         node_definition
       end
       @id = @attributes['@id']
-      @anon = @id.nil? || @id.to_s[0,2] == '_:'
+      @anon = @id.nil? || @id.to_s.start_with?('_:')
     end
 
     ##

--- a/lib/json/ld/resource.rb
+++ b/lib/json/ld/resource.rb
@@ -188,7 +188,7 @@ module JSON::LD
 
       #$logger.debug "resolve(0): #{attributes.inspect}"
       @attributes.each do |k, v|
-        next if %w(id type).include?(k)
+        next if k == 'id' || k == 'type'
         @attributes[k] = update_obj(@attributes[k], reference_map)
       end
       #$logger.debug "resolve(1): #{attributes.inspect}"

--- a/lib/json/ld/utils.rb
+++ b/lib/json/ld/utils.rb
@@ -20,7 +20,7 @@ module JSON::LD
     # @param [Object] value
     # @return [Boolean]
     def node_reference?(value)
-      value.is_a?(Hash) && value.keys == %w(@id)
+      value.is_a?(Hash) && value.length == 1 && value.key?('@id')
     end
 
     ##

--- a/lib/json/ld/utils.rb
+++ b/lib/json/ld/utils.rb
@@ -40,9 +40,9 @@ module JSON::LD
     def blank_node?(value)
       case value
       when nil    then true
-      when String then value[0,2] == '_:'
+      when String then value.start_with?('_:')
       else
-        (node?(value) || node_reference?(value)) && value.fetch('@id', '_:')[0,2] == '_:'
+        (node?(value) || node_reference?(value)) && value.fetch('@id', '_:').start_with?('_:')
       end
     end
 
@@ -80,7 +80,7 @@ module JSON::LD
     # @return [RDF::Resource]
     def as_resource(id, base = nil)
       @nodes ||= {} # Re-use BNodes
-      if id[0,2] == '_:'
+      if id.start_with?('_:')
         (@nodes[id] ||= RDF::Node.new(namer.get_sym(id)))
       elsif base
         base.join(id)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,10 +14,10 @@ require 'rdf/spec/matchers'
 require 'yaml'
 begin
   require 'simplecov'
-  require 'coveralls'
+  require 'coveralls' unless ENV['NOCOVERALLS']
   SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
     SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter
+    (Coveralls::SimpleCov::Formatter unless ENV['NOCOVERALLS'])
   ])
   SimpleCov.start do
     add_filter "/spec/"

--- a/spec/suite_helper.rb
+++ b/spec/suite_helper.rb
@@ -5,7 +5,7 @@ require 'support/extensions'
 # For now, override RDF::Utils::File.open_file to look for the file locally before attempting to retrieve it
 module RDF::Util
   module File
-    REMOTE_PATH = "http://json-ld.org/test-suite/"
+    REMOTE_PATH = "https://json-ld.org/test-suite/"
     LOCAL_PATH = ::File.expand_path("../json-ld.org/test-suite", __FILE__) + '/'
 
     class << self
@@ -69,7 +69,7 @@ end
 
 module Fixtures
   module SuiteTest
-    SUITE = RDF::URI("http://json-ld.org/test-suite/")
+    SUITE = RDF::URI("https://json-ld.org/test-suite/")
 
     class Manifest < JSON::LD::Resource
       def self.open(file)
@@ -287,7 +287,7 @@ module Fixtures
       end
     end
 
-    REMOTE_PATH = "http://json-ld.org/test-suite/"
+    REMOTE_PATH = "https://json-ld.org/test-suite/"
     LOCAL_PATH = ::File.expand_path("../json-ld.org/test-suite", __FILE__) + '/'
     ##
     # Document loader to use for tests having `useDocumentLoader` option


### PR DESCRIPTION
# Summary

This PR contains all the improvements I made from profiling the `JSON::LD::API#frame` method.

If all commits from this PR and sister PR https://github.com/ruby-rdf/rdf/pull/360 are applied, the number of objects allocated in my sample scenario drops around 32% and the runtime is improved by 20% (on Ruby 2.4, which is recommended because of the frozen string literal feature).

I would appreciate if you can do some code review before accepting the PR @gkellogg .

# The details

I did not have the chance to run the whole json-ld test suite (broken since #40) but at least for each commit I verified that the `CI=true bundle exec rake spec` command passes, and that there is no regression in the ntriple representation of the graph that I have been framing.

This PR was developed using a sample scenario (ntriples graph that we want to frame to a certain context). The scenario was run multiple times (here 10) and I kept track of ruby object allocations using [stackprof](https://github.com/tmm1/stackprof).

The sample scenario run 10 times would allocate 906000 objects at the start, and at the end only 623000, a reduction of around 32% of allocated objects. The run time was cut by around 20% (on ruby 2.4).

Here was my progression in reducing the allocated object count (each step should have a corresponding commit in this PR):
  - starting with 906120 objects allocated.
  - json-ld:
    - [+1k] replace KEYWORDS=%w[] with a Set (to optimize multiple .include calls) => 907840
    - [-64k] rework Array#kw_sort to use a cache of KW_ORDERS for faster lookups and less object allocations => 843600
    - [-24k] remplace `mystring[0,2] == '//'` with `mystring.start_with?('//')` => 819770
    - [-10k] remove 1 line of expensive unused code: `keys = ordered ? input.keys.kw_sort : input.keys` => 809580
    - [-45k] hunt uses of .keys.any?, .keys.include?, .keys == %w(), .keys.length => 764350
    - [-19k] hunt use of .keys.reject .keys.select, keys.inject ... => 745730
    - [-29k] hunt use of `%w().include?`	 and `].include?` => 716860
    - [-3k] hunt use of `== []`, `== {}`, `!= []`, `!= {}` , replace with .empty? predicate => 713610
    - [-10k] replace `(object.keys & %w[value1 value2]).length < 2` with `if !(object.key?(value1) && object.key?(value2))` => 703930
    - [-1k] refactor `.reject.each` and `.reject.map` to not allocate temporary array (thanks 'next if') => 702900
    - [-10k] refactor `output_object.delete('@type') if Array(output_object['@type']).join('').to_s.empty?` en `output_object.delete('@type') if output_object.key?('@type') && output_object['@type'].nil?` => 692020
    - [-8k] replace all use of `.inject` with more efficient `.each_with_object` => 684590
    - [-7k] replace `map..flatten.compact` instance with `.each_with_object` => 677990
    - [-0k] replace `mapping -= %w('@set')` with `mapping.delete('@set')` => 677990
    - [-0k] replace `.dup.delete_if` with `.reject` => 677990
    - [-16k] replace `defined: {}` in function keyword args with `defined: nil` followed with `defined = defined || {}` because parameter seldom used => 661760
    - [-4k] refactor `JSON::LD::Frame#count_blank_node_identifiers` to allocate results hash only once => 657870
  - rdf:
    - [-6k] replace `matchdata.to_a[1..-1]` with `matchdata[1..-1]` => 651111
    - [-18k] replace `def method(*args) if (first=args.first) ...` with `def method(first, *args)` => 633651
    - [-7k] replace `property.to_s =~ /regexp/` with constant regexp and `REGEXP.match(property)` (regexp.match cares about casting nil and symbol to String) => 626961
    - [-3k] reduce unneeded object allocations in RDF::Utils::Logger#logger_common => 623851
