### PR TITLE
Stackprof profiling

### DIFF
--- a/lib/json/ld/compact.rb
+++ b/lib/json/ld/compact.rb
@@ -4,6 +4,9 @@ module JSON::LD
   module Compact
     include Utils
 
+    # The following constant is used to reduce object allocations in #compact below
+    CONTAINER_MAPPING_LANGUAGE_INDEX_ID_TYPE = Set.new(%w(@language @index @id @type)).freeze
+
     ##
     # This algorithm compacts a JSON-LD document, such that the given context is applied. This must result in shortening any applicable IRIs to terms or compact IRIs, any applicable keywords to keyword aliases, and any applicable JSON-LD values expressed in expanded form to simple values such as strings or numbers.
     #
@@ -234,7 +237,7 @@ module JSON::LD
                 add_value(nest_result, item_active_property, compacted_item,
                   property_is_array: as_array)
               end
-            elsif !(container & %w(@language @index @id @type)).empty? && !container.include?('@graph')
+            elsif container.any? { |key| CONTAINER_MAPPING_LANGUAGE_INDEX_ID_TYPE.include?(key) } && !container.include?('@graph')
               map_object = nest_result[item_active_property] ||= {}
               c = container.first
               container_key = context.compact_iri(c, vocab: true, quiet: true)


### PR DESCRIPTION
This PR is a new episode in the "stackprof profiling" series (after https://github.com/ruby-rdf/rdf/pull/382).

It consists in multiple changesets, each with small refactors from allocation-intensive code found by profiling the following code:

```
# frozen_string_literal: true
require 'stackprof'

require 'json/ld'
require 'rdf/ntriples'

$json = {
  '@id' => 'uuid:aymeric',
  '@type' => 'pmcore:Person',
  'rdfs:label' => 'Aymeric Brisse',
  'pmcore:date' => ['2010-05-29'],
  'pmcore:dateTime' => '2010-05-29T14:17:39+02:00',
  'pmcore:string' => '2010-05-29',
  'pmcore:int' => '2010',
  'pmcore:literal' => nil,
  'pmcore:relation' => [],
  'pmcore:otherRelation' => [{
    '@id' => 'kb:Agent',
    'pmcore:float' => '42.42'
  }],
  'pmcore:blankRelation' => {
    'rdfs:label' => 'Label',
    'pmcore:anotherRelation' => {
      '@id' => 'kb:Marc'
    }
  }
}

def load_graph_file(*args, format: :ntriples)
  file = File.join(File.dirname(__FILE__), args)

  RDF::Repository.new.tap do |repository|
    RDF::Reader.for(format).open(file) do |reader|
      repository << reader.statements
    end
  end
end

def parsing(json)
  json['@context'] = {"rdf"=>"http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rdfs"=>"http://www.w3.org/2000/01/rdf-schema#", "pmmodel"=>"http://www.perfect-memory.com/ontology/pmmodel/1.1#", "pmcore"=>"http://www.perfect-memory.com/ontology/pmcore/1.1#", "pmbroadcast"=>"http://www.perfect-memory.com/ontology/pmbroadcast/1.1#", "pmmultimedia"=>"http://www.perfect-memory.com/ontology/pmmultimedia/1.1#", "pmright"=>"http://www.perfect-memory.com/ontology/pmright/1.1#", "showroom"=>"http://www.perfect-memory.com/ontology/showroom/1.1#", "tmp"=>"http://www.perfect-memory.com/profile/tmp/resource/", "wisdom"=>"http://www.perfect-memory.com/ontology/wisdom/1.1#", "wisdom-kb"=>"http://www.perfect-memory.com/profile/wisdom/kb/", "kb"=>"http://www.perfect-memory.com/profile/showroom/kb/", "uuid"=>"http://www.perfect-memory.com/profile/showroom/resource/", "rdfs:label"=>{"@language"=>"en"}, "pmcore:date"=>{"@type"=>"http://www.w3.org/2001/XMLSchema#date"}, "pmcore:dateTime"=>{"@type"=>"http://www.w3.org/2001/XMLSchema#dateTime"}, "pmcore:string"=>{"@type"=>"http://www.w3.org/2001/XMLSchema#string"}, "pmcore:int"=>{"@type"=>"http://www.w3.org/2001/XMLSchema#int"}, "pmcore:literal"=>{"@language"=>"en"}, "pmcore:float"=>{"@type"=>"http://www.w3.org/2001/XMLSchema#float"}, "pmcore:blankRelation"=>{"@language"=>"en"}, "pmcore:anotherRelation"=>{"@language"=>"en"}}

  g = RDF::Graph.new.tap do |graph|
    ::JSON::LD::API.toRDF(json) do |statement|
      graph << statement
    end
  end
end

def dumping(graph)
  framing = {"@context"=>{"rdf"=>"http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rdfs"=>"http://www.w3.org/2000/01/rdf-schema#", "pmmodel"=>"http://www.perfect-memory.com/ontology/pmmodel/1.1#", "pmcore"=>"http://www.perfect-memory.com/ontology/pmcore/1.1#", "pmbroadcast"=>"http://www.perfect-memory.com/ontology/pmbroadcast/1.1#", "pmmultimedia"=>"http://www.perfect-memory.com/ontology/pmmultimedia/1.1#", "pmright"=>"http://www.perfect-memory.com/ontology/pmright/1.1#", "showroom"=>"http://www.perfect-memory.com/ontology/showroom/1.1#", "tmp"=>"http://www.perfect-memory.com/profile/tmp/resource/", "wisdom"=>"http://www.perfect-memory.com/ontology/wisdom/1.1#", "wisdom-kb"=>"http://www.perfect-memory.com/profile/wisdom/kb/", "kb"=>"http://www.perfect-memory.com/profile/showroom/kb/", "uuid"=>"http://www.perfect-memory.com/profile/showroom/resource/"}, "@embed"=>"@always", "@id"=>"http://www.perfect-memory.com/profile/showroom/resource/cfa95511-5320-4fb8-a0bd-e7738d1fcea3"}

  json = JSON::LD::API.fromRdf(graph, useNativeTypes: true) do |expanded|
    JSON::LD::API.frame(expanded, framing)
  end

  json['@graph']
end

def processing(_i)
  [].tap do |memo|
    10.times.each do
      memo << parsing($json.dup).class
    end
    memo << dumping(load_graph_file('repository.nt')).class
  end
end

# speed
require "benchmark"
Benchmark.bmbm do |bm|
  bm.report('current code') do
    (1..100).each do |i|
      processing(i)
    end
  end
end

# stackprof
memo = {}
#StackProf.run(mode: :cpu, out: 'tmp/stackprof-myapp.dump', interval: 1000) do
StackProf.run(mode: :object, out: 'tmp/stackprof-myapp.dump', interval: 1) do
  (1..100).each do |i|
    memo[i] = processing(i)
  end
end
memo
```

I first profiled the `#parsing` method with great success (for 1000 iterations, I dropped number of allocated objects from 2.992 to 1.95 million (even if 640k objects were due to a change introduced by one of my recent work on rdf, which I will fix in a separate PR there). Then I profiled the `#dumping` method with less impressive results (I think that I optimized that code a couple years ago already).

Can you review each changeset and tell me if you like them?
The `bundle exec rake spec` passes with all my changes, same as on the `develop` branch.