### PR TITLE
fix(performance): comment all log_debug

### DIFF
--- a/lib/json/ld/api.rb
+++ b/lib/json/ld/api.rb
@@ -236,7 +236,7 @@ module JSON::LD
       end
 
       API.new(expanded_input, context, no_default_base: true, **options) do
-        log_debug(".compact") {"expanded input: #{expanded_input.to_json(JSON_STATE) rescue 'malformed json'}"}
+        # log_debug(".compact") {"expanded input: #{expanded_input.to_json(JSON_STATE) rescue 'malformed json'}"}
         result = compact(value)
 
         # xxx) Add the given context to the output
@@ -290,7 +290,7 @@ module JSON::LD
 
       # Initialize input using
       API.new(expanded_input, context, no_default_base: true, **options) do
-        log_debug(".flatten") {"expanded input: #{value.to_json(JSON_STATE) rescue 'malformed json'}"}
+        # log_debug(".flatten") {"expanded input: #{value.to_json(JSON_STATE) rescue 'malformed json'}"}
 
         # Rename blank nodes recusively. Note that this does not create new blank node identifiers where none exist, which is performed in the node map generation algorithm.
         @value = rename_bnodes(@value) if @options[:rename_bnodes]
@@ -411,8 +411,8 @@ module JSON::LD
 
       # Initialize input using frame as context
       API.new(expanded_input, frame['@context'], no_default_base: true, **options) do
-        log_debug(".frame") {"expanded input: #{expanded_input.to_json(JSON_STATE) rescue 'malformed json'}"}
-        log_debug(".frame") {"expanded frame: #{expanded_frame.to_json(JSON_STATE) rescue 'malformed json'}"}
+        # log_debug(".frame") {"expanded input: #{expanded_input.to_json(JSON_STATE) rescue 'malformed json'}"}
+        # log_debug(".frame") {"expanded frame: #{expanded_frame.to_json(JSON_STATE) rescue 'malformed json'}"}
 
         if %w(@first @last).include?(options[:embed]) && context.processingMode('json-ld-1.1')
           raise JSON::LD::JsonLdError::InvalidEmbedValue, "#{options[:embed]} is not a valid value of @embed in 1.1 mode" if @options[:validate]
@@ -459,7 +459,7 @@ module JSON::LD
 
         # Replace values with `@preserve` with the content of its entry.
         result = cleanup_preserve(result)
-        log_debug(".frame") {"expanded result: #{result.to_json(JSON_STATE) rescue 'malformed json'}"}
+        # log_debug(".frame") {"expanded result: #{result.to_json(JSON_STATE) rescue 'malformed json'}"}
 
         # Compact result
         compacted = compact(result)
@@ -478,7 +478,7 @@ module JSON::LD
         # Only add context if one was provided
         result = context.serialize(provided_context: frame).merge(result) if frame['@context']
         
-        log_debug(".frame") {"after compact: #{result.to_json(JSON_STATE) rescue 'malformed json'}"}
+        # log_debug(".frame") {"after compact: #{result.to_json(JSON_STATE) rescue 'malformed json'}"}
         result
       end
 
@@ -519,7 +519,7 @@ module JSON::LD
       API.new(flattened_input, nil, **options) do
         # 1) Perform the Expansion Algorithm on the JSON-LD input.
         #    This removes any existing context to allow the given context to be cleanly applied.
-        log_debug(".toRdf") {"flattened input: #{flattened_input.to_json(JSON_STATE) rescue 'malformed json'}"}
+        # log_debug(".toRdf") {"flattened input: #{flattened_input.to_json(JSON_STATE) rescue 'malformed json'}"}
 
         # Recurse through input
         flattened_input.each do |node|
@@ -528,7 +528,7 @@ module JSON::LD
 
             # Drop invalid statements (other than IRIs)
             unless statement.valid_extended?
-              log_debug(".toRdf") {"drop invalid statement: #{statement.to_nquads}"}
+              # log_debug(".toRdf") {"drop invalid statement: #{statement.to_nquads}"}
               next
             end
 

--- a/lib/json/ld/compact.rb
+++ b/lib/json/ld/compact.rb
@@ -21,14 +21,14 @@ module JSON::LD
                 base: nil,
                 property: nil,
                 log_depth: nil)
-      log_debug("compact", depth: log_depth.to_i) {"element: #{element.inspect}, ec: #{context.inspect}"}
+      # log_debug("compact", depth: log_depth.to_i) {"element: #{element.inspect}, ec: #{context.inspect}"}
 
       # If the term definition for active property itself contains a context, use that for compacting values.
       input_context = self.context
 
       case element
       when Array
-        #log_debug("") {"Array #{element.inspect}"}
+        # log_debug("") {"Array #{element.inspect}"}
         result = element.map do |item|
           compact(item, base: base, property: property, log_depth: log_depth.to_i + 1)
         end.compact
@@ -38,10 +38,10 @@ module JSON::LD
         # member; otherwise the compacted value is element
         if result.length == 1 &&
            !context.as_array?(property) && @options[:compactArrays]
-          log_debug("=> extract single element", depth: log_depth.to_i) {result.first.inspect}
+          # log_debug("=> extract single element", depth: log_depth.to_i) {result.first.inspect}
           result.first
         else
-          log_debug("=> array result", depth: log_depth.to_i) {result.inspect}
+          # log_debug("=> array result", depth: log_depth.to_i) {result.inspect}
           result
         end
       when Hash
@@ -52,7 +52,7 @@ module JSON::LD
 
         # Revert any previously type-scoped (non-preserved) context
         if context.previous_context && !element.key?('@value') && element.keys != %w(@id)
-          log_debug("revert ec", depth: log_depth.to_i) {"previous context: #{context.previous_context.inspect}"}
+          # log_debug("revert ec", depth: log_depth.to_i) {"previous context: #{context.previous_context.inspect}"}
           self.context = context.previous_context
         end
 
@@ -61,13 +61,13 @@ module JSON::LD
         if td && !td.context.nil?
           self.context = context.parse(td.context,
             override_protected: true)
-          log_debug("prop-scoped", depth: log_depth.to_i) {"context: #{self.context.inspect}"}
+          # log_debug("prop-scoped", depth: log_depth.to_i) {"context: #{self.context.inspect}"}
         end
 
         if (element.key?('@id') || element.key?('@value')) && !element.key?('@annotation')
           result = context.compact_value(property, element, base: @options[:base])
           if !result.is_a?(Hash) || context.coerce(property) == '@json'
-            log_debug("", depth: log_depth.to_i) {"=> scalar result: #{result.inspect}"}
+            # log_debug("", depth: log_depth.to_i) {"=> scalar result: #{result.inspect}"}
             return result
           end
         end
@@ -90,12 +90,12 @@ module JSON::LD
           each do |term|
           term_context = input_context.term_definitions[term].context if input_context.term_definitions[term]
           self.context = context.parse(term_context, propagate: false) unless term_context.nil?
-          log_debug("type-scoped", depth: log_depth.to_i) {"context: #{self.context.inspect}"}
+          # log_debug("type-scoped", depth: log_depth.to_i) {"context: #{self.context.inspect}"}
         end
 
         element.keys.opt_sort(ordered: @options[:ordered]).each do |expanded_property|
           expanded_value = element[expanded_property]
-          log_debug("", depth: log_depth.to_i) {"#{expanded_property}: #{expanded_value.inspect}"}
+          # log_debug("", depth: log_depth.to_i) {"#{expanded_property}: #{expanded_value.inspect}"}
 
           if expanded_property == '@id'
             compacted_value = as_array(expanded_value).map do |expanded_id|
@@ -134,7 +134,7 @@ module JSON::LD
             compacted_value = compact(expanded_value, base: base,
                                       property: '@reverse',
                                       log_depth: log_depth.to_i + 1)
-            log_debug("@reverse", depth: log_depth.to_i) {"compacted_value: #{compacted_value.inspect}"}
+            # log_debug("@reverse", depth: log_depth.to_i) {"compacted_value: #{compacted_value.inspect}"}
             # handle double-reversed properties
             compacted_value.each do |prop, value|
               if context.reverse?(prop)
@@ -146,7 +146,7 @@ module JSON::LD
 
             unless compacted_value.empty?
               al = context.compact_iri('@reverse', vocab: true)
-              log_debug("", depth: log_depth.to_i) {"remainder: #{al} => #{compacted_value.inspect}"}
+              # log_debug("", depth: log_depth.to_i) {"remainder: #{al} => #{compacted_value.inspect}"}
               result[al] = compacted_value
             end
             next
@@ -157,7 +157,7 @@ module JSON::LD
             compacted_value = compact(expanded_value, base: base,
                                       property: property,
                                       log_depth: log_depth.to_i + 1)
-            log_debug("@preserve", depth: log_depth.to_i) {"compacted_value: #{compacted_value.inspect}"}
+            # log_debug("@preserve", depth: log_depth.to_i) {"compacted_value: #{compacted_value.inspect}"}
 
             unless compacted_value.is_a?(Array) && compacted_value.empty?
               result['@preserve'] = compacted_value
@@ -166,14 +166,14 @@ module JSON::LD
           end
 
           if expanded_property == '@index' && context.container(property).include?('@index')
-            log_debug("@index", depth: log_depth.to_i) {"drop @index"}
+            # log_debug("@index", depth: log_depth.to_i) {"drop @index"}
             next
           end
 
           # Otherwise, if expanded property is @direction, @index, @value, or @language:
           if EXPANDED_PROPERTY_DIRECTION_INDEX_LANGUAGE_VALUE.include?(expanded_property)
             al = context.compact_iri(expanded_property, vocab: true)
-            log_debug(expanded_property, depth: log_depth.to_i) {"#{al} => #{expanded_value.inspect}"}
+            # log_debug(expanded_property, depth: log_depth.to_i) {"#{al} => #{expanded_value.inspect}"}
             result[al] = expanded_value
             next
           end
@@ -223,7 +223,7 @@ module JSON::LD
             compacted_item = compact(value, base: base,
                                      property: item_active_property,
                                      log_depth: log_depth.to_i + 1)
-            log_debug("", depth: log_depth.to_i) {" => compacted key: #{item_active_property.inspect} for #{compacted_item.inspect}"}
+            # log_debug("", depth: log_depth.to_i) {" => compacted key: #{item_active_property.inspect} for #{compacted_item.inspect}"}
 
             # handle @list
             if list?(expanded_item)
@@ -345,7 +345,7 @@ module JSON::LD
         result
       else
         # For other types, the compacted value is the element value
-        log_debug("compact", depth: log_depth.to_i) {element.class.to_s}
+        # log_debug("compact", depth: log_depth.to_i) {element.class.to_s}
         element
       end
 

--- a/lib/json/ld/context.rb
+++ b/lib/json/ld/context.rb
@@ -212,7 +212,7 @@ module JSON::LD
       self.default_language = options[:language] if options[:language] =~ /^[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*$/
       @term_definitions = options[:term_definitions] if options[:term_definitions]
 
-      #log_debug("init") {"iri_to_term: #{iri_to_term.inspect}"}
+      # log_debug("init") {"iri_to_term: #{iri_to_term.inspect}"}
 
       yield(self) if block_given?
     end
@@ -267,10 +267,10 @@ module JSON::LD
                   "Attempt to clear a context with protected terms"
           end
         when Context
-           log_debug("parse") {"context: #{context.inspect}"}
+           # log_debug("parse") {"context: #{context.inspect}"}
            result = result.merge(context)
         when IO, StringIO
-          log_debug("parse") {"io: #{context}"}
+          # log_debug("parse") {"io: #{context}"}
           # Load context document, if it is an open file
           begin
             ctx = load_context(context, **@options)
@@ -282,7 +282,7 @@ module JSON::LD
             self
           end
         when String, RDF::URI
-          log_debug("parse") {"remote: #{context}, base: #{result.context_base || result.base}"}
+          # log_debug("parse") {"remote: #{context}, base: #{result.context_base || result.base}"}
 
           # 3.2.1) Set context to the result of resolving value against the base IRI which is established as specified in section 5.1 Establishing a Base URI of [RFC3986]. Only the basic algorithm in section 5.2 of [RFC3986] is used; neither Syntax-Based Normalization nor Scheme-Based Normalization are performed. Characters additionally allowed in IRI references are treated in the same way that unreserved characters are treated in URI references, per section 6.5 of [RFC3987].
           context = RDF::URI(result.context_base || base).join(context)
@@ -297,11 +297,11 @@ module JSON::LD
 
           cached_context = if PRELOADED[context_canon.to_s]
             # If we have a cached context, merge it into the current context (result) and use as the new context
-            log_debug("parse") {"=> cached_context: #{context_canon.to_s.inspect}"}
+            # log_debug("parse") {"=> cached_context: #{context_canon.to_s.inspect}"}
 
             # If this is a Proc, then replace the entry with the result of running the Proc
             if PRELOADED[context_canon.to_s].respond_to?(:call)
-              log_debug("parse") {"=> (call)"}
+              # log_debug("parse") {"=> (call)"}
               PRELOADED[context_canon.to_s] = PRELOADED[context_canon.to_s].call
             end
             PRELOADED[context_canon.to_s].context_base ||= context_canon.to_s
@@ -479,7 +479,7 @@ module JSON::LD
         remote_contexts: [],
         validate_scoped: true)
       # Expand a string value, unless it matches a keyword
-      log_debug("create_term_definition") {"term = #{term.inspect}"}
+      # log_debug("create_term_definition") {"term = #{term.inspect}"}
 
       # If defined contains the key term, then the associated value must be true, indicating that the term definition has already been created, so return. Otherwise, a cyclical term definition has been detected, which is an error.
       case defined[term]
@@ -524,7 +524,7 @@ module JSON::LD
 
       raise JsonLdError::InvalidTermDefinition, "Term definition for #{term.inspect} is an #{value.class} on term #{term.inspect}" unless value.is_a?(Hash)
 
-      #log_debug("") {"Hash[#{term.inspect}] = #{value.inspect}"}
+      # log_debug("") {"Hash[#{term.inspect}] = #{value.inspect}"}
       definition = TermDefinition.new(term)
       definition.simple = simple_term
 
@@ -566,7 +566,7 @@ module JSON::LD
         elsif !JSON_LD_10_TYPE_VALUES.include?(type) && !(type.is_a?(RDF::URI) && type.absolute?)
           raise JsonLdError::InvalidTypeMapping, "unknown mapping for '@type': #{type.inspect} on term #{term.inspect}"
         end
-        #log_debug("") {"type_mapping: #{type.inspect}"}
+        # log_debug("") {"type_mapping: #{type.inspect}"}
         definition.type_mapping = type
       end
 
@@ -650,7 +650,7 @@ module JSON::LD
           # Otherwise, term is an absolute IRI. Set the IRI mapping for definition to term
           term
         end
-        log_debug("") {"=> #{definition.id}"}
+        # log_debug("") {"=> #{definition.id}"}
       elsif term.include?('/')
         # If term is a relative IRI
         definition.id = expand_iri(term, vocab: true)
@@ -663,13 +663,13 @@ module JSON::LD
         # Otherwise, active context must have a vocabulary mapping, otherwise an invalid value has been detected, which is an error. Set the IRI mapping for definition to the result of concatenating the value associated with the vocabulary mapping and term.
         raise JsonLdError::InvalidIRIMapping, "relative term definition without vocab: #{term} on term #{term.inspect}" unless vocab
         definition.id = vocab + term
-        log_debug("") {"=> #{definition.id}"}
+        # log_debug("") {"=> #{definition.id}"}
       end
 
       @iri_to_term[definition.id] = term if simple_term && definition.id
 
       if value.key?('@container')
-        #log_debug("") {"container_mapping: #{value['@container'].inspect}"}
+        # log_debug("") {"container_mapping: #{value['@container'].inspect}"}
         definition.container_mapping = check_container(value['@container'], local_context, defined, term)
 
         # If @container includes @type
@@ -703,7 +703,7 @@ module JSON::LD
           when nil then [nil]
           else value['@context']
           end
-          log_debug("") {"context: #{definition.context.inspect}"}
+          # log_debug("") {"context: #{definition.context.inspect}"}
         rescue JsonLdError => e
           raise JsonLdError::InvalidScopedContext, "Term definition for #{term.inspect} contains illegal value for @context: #{e.message}"
         end
@@ -723,14 +723,14 @@ module JSON::LD
         else
           raise JsonLdError::InvalidLanguageMapping, "language must be null or a string, was #{value['@language'].inspect}} on term #{term.inspect}"
         end
-        #log_debug("") {"language_mapping: #{language.inspect}"}
+        # log_debug("") {"language_mapping: #{language.inspect}"}
         definition.language_mapping = language || false
       end
 
       if value.key?('@direction')
         direction = value['@direction']
         raise JsonLdError::InvalidBaseDirection, "direction must be null, 'ltr', or 'rtl', was #{language.inspect}} on term #{term.inspect}" unless direction.nil? || %w(ltr rtl).include?(direction)
-        #log_debug("") {"direction_mapping: #{direction.inspect}"}
+        # log_debug("") {"direction_mapping: #{direction.inspect}"}
         definition.direction_mapping = direction || false
       end
 
@@ -738,7 +738,7 @@ module JSON::LD
         nest = value['@nest']
         raise JsonLdError::InvalidNestValue, "nest must be a string, was #{nest.inspect}} on term #{term.inspect}" unless nest.is_a?(String)
         raise JsonLdError::InvalidNestValue, "nest must not be a keyword other than @nest, was #{nest.inspect}} on term #{term.inspect}" if nest.match?(/^@[a-zA-Z]+$/) && nest != '@nest'
-        #log_debug("") {"nest: #{nest.inspect}"}
+        # log_debug("") {"nest: #{nest.inspect}"}
         definition.nest = nest
       end
 
@@ -898,18 +898,18 @@ module JSON::LD
     # @param  [Hash{Symbol => Object}] options ({})
     # @return [Hash]
     def serialize(provided_context: nil, **options)
-      #log_debug("serlialize: generate context")
-      #log_debug("") {"=> context: #{inspect}"}
+      # log_debug("serlialize: generate context")
+      # log_debug("") {"=> context: #{inspect}"}
       use_context = case provided_context
       when String, RDF::URI
-        #log_debug "serlialize: reuse context: #{provided_context.inspect}"
+        # log_debug "serlialize: reuse context: #{provided_context.inspect}"
         provided_context.to_s
       when Hash
-        #log_debug "serlialize: reuse context: #{provided_context.inspect}"
+        # log_debug "serlialize: reuse context: #{provided_context.inspect}"
         # If it has an @context entry use it, otherwise it is assumed to be the body of a context
         provided_context.fetch('@context', provided_context)
       when Array
-        #log_debug "serlialize: reuse context: #{provided_context.inspect}"
+        # log_debug "serlialize: reuse context: #{provided_context.inspect}"
         provided_context
       when IO, StringIO
         load_context(provided_context, **@options).fetch('@context', {})
@@ -1015,7 +1015,7 @@ module JSON::LD
     #
     # @return [TermDefinition]
     def set_mapping(term, value)
-      #log_debug("") {"map #{term.inspect} to #{value.inspect}"}
+      # log_debug("") {"map #{term.inspect} to #{value.inspect}"}
       term = term.to_s
       term_definitions[term] = TermDefinition.new(term, id: value, simple: true, prefix: (value.to_s.end_with?(*PREFIX_URI_ENDINGS)))
       term_definitions[term].simple = true
@@ -1489,7 +1489,7 @@ module JSON::LD
 
       # If the active property has a type mapping in active context that is @id, return a new JSON object containing a single key-value pair where the key is @id and the value is the result of using the IRI Expansion algorithm, passing active context, value, and true for document relative.
       if value.is_a?(String) && td.type_mapping == '@id'
-        #log_debug("") {"as relative IRI: #{value.inspect}"}
+        # log_debug("") {"as relative IRI: #{value.inspect}"}
         return {'@id' => expand_iri(value, documentRelative: true, base: base).to_s}
       end
 
@@ -1537,7 +1537,7 @@ module JSON::LD
     # @see https://www.w3.org/TR/json-ld11-api/#value-compaction
     # FIXME: revisit the specification version of this.
     def compact_value(property, value, base: nil)
-      #log_debug("compact_value") {"property: #{property.inspect}, value: #{value.inspect}"}
+      # log_debug("compact_value") {"property: #{property.inspect}, value: #{value.inspect}"}
 
       indexing = index?(value) && container(property).include?('@index')
       language = language(property)
@@ -1546,25 +1546,25 @@ module JSON::LD
       result = case
       when coerce(property) == '@id' && value.key?('@id') && (value.keys - %w(@id @index)).empty?
         # Compact an @id coercion
-        #log_debug("") {" (@id & coerce)"}
+        # log_debug("") {" (@id & coerce)"}
         compact_iri(value['@id'], base: base)
       when coerce(property) == '@vocab' && value.key?('@id') && (value.keys - %w(@id @index)).empty?
         # Compact an @id coercion
-        #log_debug("") {" (@id & coerce & vocab)"}
+        # log_debug("") {" (@id & coerce & vocab)"}
         compact_iri(value['@id'], vocab: true)
       when value.key?('@id')
-        #log_debug("") {" (@id)"}
+        # log_debug("") {" (@id)"}
         # return value as is
         value
       when value['@type'] && value['@type'] == coerce(property)
         # Compact common datatype
-        #log_debug("") {" (@type & coerce) == #{coerce(property)}"}
+        # log_debug("") {" (@type & coerce) == #{coerce(property)}"}
         value['@value']
       when coerce(property) == '@none' || value['@type']
         # use original expanded value
         value
       when !value['@value'].is_a?(String)
-        #log_debug("") {" (native)"}
+        # log_debug("") {" (native)"}
         indexing || !index?(value) ? value['@value'] : value
       when value['@language'].to_s.downcase == language.to_s.downcase && value['@direction'] == direction
         # Compact language and direction
@@ -1585,7 +1585,7 @@ module JSON::LD
       
       # If the result is an object, tranform keys using any term keyword aliases
       if result.is_a?(Hash) && result.keys.any? {|k| self.alias(k) != k}
-        #log_debug("") {" (map to key aliases)"}
+        # log_debug("") {" (map to key aliases)"}
         new_element = {}
         result.each do |k, v|
           new_element[self.alias(k)] = v
@@ -1593,7 +1593,7 @@ module JSON::LD
         result = new_element
       end
 
-      #log_debug("") {"=> #{result.inspect}"}
+      # log_debug("") {"=> #{result.inspect}"}
       result
     end
 
@@ -1703,7 +1703,7 @@ module JSON::LD
       case value.to_s
       when /^_:(.*)$/
         # Map BlankNodes if a namer is given
-        #log_debug "uri(bnode)#{value}: #{$1}"
+        # log_debug "uri(bnode)#{value}: #{$1}"
         bnode(namer.get_sym($1))
       else
         value = RDF::URI(value)
@@ -1822,25 +1822,25 @@ module JSON::LD
     #   for the type mapping or language mapping
     # @return [String]
     def select_term(iri, containers, type_language, preferred_values)
-      #log_debug("select_term") {
+      # log_debug("select_term") {
       #  "iri: #{iri.inspect}, " +
       #  "containers: #{containers.inspect}, " +
       #  "type_language: #{type_language.inspect}, " +
       #  "preferred_values: #{preferred_values.inspect}"
       #}
       container_map = inverse_context[iri]
-      #log_debug("  ") {"container_map: #{container_map.inspect}"}
+      # log_debug("  ") {"container_map: #{container_map.inspect}"}
       containers.each do |container|
         next unless container_map.key?(container)
         tl_map = container_map[container]
         value_map = tl_map[type_language]
         preferred_values.each do |item|
           next unless value_map.key?(item)
-          #log_debug("=>") {value_map[item].inspect}
+          # log_debug("=>") {value_map[item].inspect}
           return value_map[item]
         end
       end
-      #log_debug("=>") {"nil"}
+      # log_debug("=>") {"nil"}
       nil
     end
 

--- a/lib/json/ld/expand.rb
+++ b/lib/json/ld/expand.rb
@@ -29,13 +29,13 @@ module JSON::LD
     # @return [Array<Hash{String => Object}>]
     def expand(input, active_property, context,
                framing: false, from_map: false, log_depth: nil)
-      log_debug("expand", depth: log_depth.to_i) {"input: #{input.inspect}, active_property: #{active_property.inspect}, context: #{context.inspect}"}
+      # log_debug("expand", depth: log_depth.to_i) {"input: #{input.inspect}, active_property: #{active_property.inspect}, context: #{context.inspect}"}
       framing = false if active_property == '@default'
       expanded_active_property = context.expand_iri(active_property, vocab: true, as_string: true, base: @options[:base]) if active_property
 
       # Use a term-specific context, if defined, based on the non-type-scoped context.
       property_scoped_context = context.term_definitions[active_property].context if active_property && context.term_definitions[active_property]
-      log_debug("expand", depth: log_depth.to_i) {"property_scoped_context: #{property_scoped_context.inspect}"} unless property_scoped_context.nil?
+      # log_debug("expand", depth: log_depth.to_i) {"property_scoped_context: #{property_scoped_context.inspect}"} unless property_scoped_context.nil?
 
       result = case input
       when Array
@@ -76,7 +76,7 @@ module JSON::LD
             !(expanded_key_map.values == ['@id'])
 
           # If there's a previous context, the context was type-scoped
-          log_debug("expand", depth: log_depth.to_i) {"previous_context: #{context.previous_context.inspect}"} if revert_context
+          # log_debug("expand", depth: log_depth.to_i) {"previous_context: #{context.previous_context.inspect}"} if revert_context
           context = context.previous_context if revert_context
         end
 
@@ -84,12 +84,12 @@ module JSON::LD
         unless property_scoped_context.nil?
           context = context.parse(property_scoped_context, base: @options[:base], override_protected: true)
         end
-        log_debug("expand", depth: log_depth.to_i) {"after property_scoped_context: #{context.inspect}"} unless property_scoped_context.nil?
+        # log_debug("expand", depth: log_depth.to_i) {"after property_scoped_context: #{context.inspect}"} unless property_scoped_context.nil?
 
         # If element contains the key @context, set active context to the result of the Context Processing algorithm, passing active context and the value of the @context key as local context.
         if input.key?('@context')
           context = context.parse(input['@context'], base: @options[:base])
-          log_debug("expand", depth: log_depth.to_i) {"context: #{context.inspect}"}
+          # log_debug("expand", depth: log_depth.to_i) {"context: #{context.inspect}"}
         end
 
         # Set the type-scoped context to the context on input, for use later
@@ -107,7 +107,7 @@ module JSON::LD
           Array(input[tk]).sort.each do |term|
             term_context = type_scoped_context.term_definitions[term].context if type_scoped_context.term_definitions[term]
             unless term_context.nil?
-              log_debug("expand", depth: log_depth.to_i) {"term_context[#{term}]: #{term_context.inspect}"}
+              # log_debug("expand", depth: log_depth.to_i) {"term_context[#{term}]: #{term_context.inspect}"}
               context = context.parse(term_context, base: @options[:base], propagate: false)
             end
           end
@@ -121,7 +121,7 @@ module JSON::LD
                       type_scoped_context: type_scoped_context,
                       log_depth: log_depth.to_i + 1)
 
-        log_debug("output object", depth: log_depth.to_i) {output_object.inspect}
+        # log_debug("output object", depth: log_depth.to_i) {output_object.inspect}
 
         # If result contains the key @value:
         if value?(output_object)
@@ -199,7 +199,7 @@ module JSON::LD
         if (expanded_active_property || '@graph') == '@graph' &&
            (output_object.key?('@value') || output_object.key?('@list') ||
            (output_object.keys - KEY_ID).empty? && !framing)
-          log_debug(" =>", depth: log_depth.to_i) { "empty top-level: " + output_object.inspect}
+          # log_debug(" =>", depth: log_depth.to_i) { "empty top-level: " + output_object.inspect}
           return nil
         end
 
@@ -219,12 +219,12 @@ module JSON::LD
                                   base: @options[:base],
                                   override_protected: true)
         end
-        log_debug("expand", depth: log_depth.to_i) {"property_scoped_context: #{context.inspect}"} unless property_scoped_context.nil?
+        # log_debug("expand", depth: log_depth.to_i) {"property_scoped_context: #{context.inspect}"} unless property_scoped_context.nil?
 
         context.expand_value(active_property, input, base: @options[:base])
       end
 
-      log_debug(depth: log_depth.to_i) {" => #{result.inspect}"}
+      # log_debug(depth: log_depth.to_i) {" => #{result.inspect}"}
       result
     end
 
@@ -258,10 +258,10 @@ module JSON::LD
           expanded_property.to_s.start_with?("_:") &&
           context.processingMode('json-ld-1.1')
 
-        log_debug("expand property", depth: log_depth.to_i) {"ap: #{active_property.inspect}, expanded: #{expanded_property.inspect}, value: #{value.inspect}"}
+        # log_debug("expand property", depth: log_depth.to_i) {"ap: #{active_property.inspect}, expanded: #{expanded_property.inspect}, value: #{value.inspect}"}
 
         if expanded_property.nil?
-          log_debug(" => ", depth: log_depth.to_i) {"skip nil property"}
+          # log_debug(" => ", depth: log_depth.to_i) {"skip nil property"}
           next
         end
 
@@ -341,7 +341,7 @@ module JSON::LD
             Array(output_object['@included']) + included_result
           when '@type'
             # If expanded property is @type and value is neither a string nor an array of strings, an invalid type value error has been detected and processing is aborted. Otherwise, set expanded value to the result of using the IRI Expansion algorithm, passing active context, true for vocab, and true for document relative to expand the value or each of its items.
-            log_debug("@type", depth: log_depth.to_i) {"value: #{value.inspect}"}
+            # log_debug("@type", depth: log_depth.to_i) {"value: #{value.inspect}"}
             e_type = case value
             when Array
               value.map do |v|
@@ -516,7 +516,7 @@ module JSON::LD
 
             # If expanded value contains an @reverse member, i.e., properties that are reversed twice, execute for each of its property and item the following steps:
             if value.key?('@reverse')
-              log_debug("@reverse", depth: log_depth.to_i) {"double reverse: #{value.inspect}"}
+              # log_debug("@reverse", depth: log_depth.to_i) {"double reverse: #{value.inspect}"}
               value['@reverse'].each do |property, item|
                 # If result does not have a property member, create one and set its value to an empty array.
                 # Append item to the value of the property member of result.
@@ -566,7 +566,7 @@ module JSON::LD
           end
 
           # Unless expanded value is null, set the expanded property member of result to expanded value.
-          log_debug("expand #{expanded_property}", depth: log_depth.to_i) { expanded_value.inspect}
+          # log_debug("expand #{expanded_property}", depth: log_depth.to_i) { expanded_value.inspect}
           output_object[expanded_property] = expanded_value unless expanded_value.nil? && expanded_property == '@value' && input_type != '@json'
           next
         end
@@ -619,7 +619,7 @@ module JSON::LD
             if id_context.nil?
               context
             else
-              log_debug("expand", depth: log_depth.to_i) {"id_context: #{id_context.inspect}"}
+              # log_debug("expand", depth: log_depth.to_i) {"id_context: #{id_context.inspect}"}
               context.parse(id_context, base: @options[:base], propagate: false)
             end
           else
@@ -632,7 +632,7 @@ module JSON::LD
             # If container mapping in the active context includes @type, and k is a term in the active context having a local context, use that context when expanding values
             map_context = container_context.term_definitions[k].context if container.include?('@type') && container_context.term_definitions[k]
             unless map_context.nil?
-              log_debug("expand", depth: log_depth.to_i) {"map_context: #{map_context.inspect}"}
+              # log_debug("expand", depth: log_depth.to_i) {"map_context: #{map_context.inspect}"}
               map_context = container_context.parse(map_context, base: @options[:base],
                                                     propagate: false)
             end
@@ -688,21 +688,21 @@ module JSON::LD
 
         # If expanded value is null, ignore key by continuing to the next key from element.
         if expanded_value.nil?
-          log_debug(" => skip nil value", depth: log_depth.to_i)
+          # log_debug(" => skip nil value", depth: log_depth.to_i)
           next
         end
-        log_debug(depth: log_depth.to_i) {" => #{expanded_value.inspect}"}
+        # log_debug(depth: log_depth.to_i) {" => #{expanded_value.inspect}"}
 
         # If the container mapping associated to key in active context is @list and expanded value is not already a list object, convert expanded value to a list object by first setting it to an array containing only expanded value if it is not already an array, and then by setting it to a JSON object containing the key-value pair @list-expanded value.
         if container.first == '@list' && container.length == 1 && !list?(expanded_value)
-          log_debug(" => ", depth: log_depth.to_i) { "convert #{expanded_value.inspect} to list"}
+          # log_debug(" => ", depth: log_depth.to_i) { "convert #{expanded_value.inspect} to list"}
           expanded_value = {'@list' => as_array(expanded_value)}
         end
-        log_debug(depth: log_depth.to_i) {" => #{expanded_value.inspect}"}
+        # log_debug(depth: log_depth.to_i) {" => #{expanded_value.inspect}"}
 
         # convert expanded value to @graph if container specifies it
         if container.first == '@graph' && container.length == 1
-          log_debug(" => ", depth: log_depth.to_i) { "convert #{expanded_value.inspect} to list"}
+          # log_debug(" => ", depth: log_depth.to_i) { "convert #{expanded_value.inspect} to list"}
           expanded_value = as_array(expanded_value).map do |v|
             {'@graph' => as_array(v)}
           end
@@ -742,7 +742,7 @@ module JSON::LD
         nest_context = if nest_context.nil?
           context
         else
-          log_debug("expand", depth: log_depth.to_i) {"nest_context: #{nest_context.inspect}"}
+          # log_debug("expand", depth: log_depth.to_i) {"nest_context: #{nest_context.inspect}"}
           context.parse(nest_context, base: @options[:base],
                         override_protected: true)
         end

--- a/lib/json/ld/from_rdf.rb
+++ b/lib/json/ld/from_rdf.rb
@@ -32,7 +32,7 @@ module JSON::LD
 
       # For each statement in dataset
       dataset.each do |statement|
-        #log_debug("statement") { statement.to_nquads.chomp}
+        # log_debug("statement") { statement.to_nquads.chomp}
 
         name = statement.graph_name ? @context.expand_iri(statement.graph_name, base: @options[:base]).to_s : '@default'
 
@@ -126,7 +126,7 @@ module JSON::LD
           list, list_nodes = [], []
 
           # If property equals rdf:rest, the value associated to the usages member of node has exactly 1 entry, node has a rdf:first and rdf:rest property, both of which have as value an array consisting of a single element, and node has no other members apart from an optional @type member whose value is an array with a single item equal to rdf:List, node represents a well-formed list node. Continue with the following steps:
-          #log_debug("list element?") {node.to_json(JSON_STATE) rescue 'malformed json'}
+          # log_debug("list element?") {node.to_json(JSON_STATE) rescue 'malformed json'}
           while property == RDF.rest.to_s &&
               blank_node?(node) &&
               referenced_once[node['@id']] &&
@@ -165,7 +165,7 @@ module JSON::LD
         node.delete(:usages)
         result << node unless node_reference?(node)
       end
-      #log_debug("fromRdf") {result.to_json(JSON_STATE) rescue 'malformed json'}
+      # log_debug("fromRdf") {result.to_json(JSON_STATE) rescue 'malformed json'}
       result
     end
 

--- a/lib/json/ld/streaming_writer.rb
+++ b/lib/json/ld/streaming_writer.rb
@@ -19,7 +19,7 @@ module JSON::LD
       else Context.parse(@options[:context])
       end
 
-      #log_debug("prologue") {"context: #{context.inspect}"}
+      # log_debug("prologue") {"context: #{context.inspect}"}
       if context
         @output.puts %({"@context": #{context.serialize['@context'].to_json}, "@graph": [)
       else
@@ -39,7 +39,7 @@ module JSON::LD
     #
     # @return [void] `self`
     def stream_statement(statement)
-      #log_debug("ss") {"state: #{@state.inspect}, stmt: #{statement}"}
+      # log_debug("ss") {"state: #{@state.inspect}, stmt: #{statement}"}
       if @current_graph != statement.graph_name
         end_graph
         start_graph(statement.graph_name)
@@ -76,7 +76,7 @@ module JSON::LD
     # Complete open statements
     # @return [void] `self`
     def stream_epilogue
-      #log_debug("epilogue") {"state: #{@state.inspect}"}
+      # log_debug("epilogue") {"state: #{@state.inspect}"}
       end_graph
       if context
         @output.puts "\n]}"
@@ -89,7 +89,7 @@ module JSON::LD
     private
     
     def start_graph(resource)
-      #log_debug("start_graph") {"state: #{@state.inspect}, resource: #{resource}"}
+      # log_debug("start_graph") {"state: #{@state.inspect}, resource: #{resource}"}
       if resource
         @output.puts(",") if %i(wrote_node wrote_graph).include?(@state)
         @output.puts %({"@id": "#{resource}", "@graph": [)
@@ -99,7 +99,7 @@ module JSON::LD
     end
 
     def end_graph
-      #log_debug("end_graph") {"state: #{@state.inspect}, ctx: #{@current_graph}"}
+      # log_debug("end_graph") {"state: #{@state.inspect}, ctx: #{@current_graph}"}
       end_node
       if @current_graph
         @output.write %(]})
@@ -108,7 +108,7 @@ module JSON::LD
     end
 
     def end_node
-      #log_debug("end_node") {"state: #{@state.inspect}, node: #{@current_node_def.to_json}"}
+      # log_debug("end_node") {"state: #{@state.inspect}, node: #{@current_node_def.to_json}"}
       @output.puts(",") if %i(wrote_node wrote_graph).include?(@state)
       if @current_node_def
         node_def = if context

--- a/lib/json/ld/to_rdf.rb
+++ b/lib/json/ld/to_rdf.rb
@@ -90,14 +90,14 @@ module JSON::LD
         to_enum(:item_to_rdf, item['@id'], quoted: true).to_a.first
       end
 
-      #log_debug("item_to_rdf")  {"subject: #{subject.to_ntriples rescue 'malformed rdf'}"}
+      # log_debug("item_to_rdf")  {"subject: #{subject.to_ntriples rescue 'malformed rdf'}"}
       item.each do |property, values|
         case property
         when '@type'
           # If property is @type, construct triple as an RDF Triple composed of id, rdf:type, and object from values where id and object are represented either as IRIs or Blank Nodes
           values.each do |v|
             object = as_resource(v)
-            #log_debug("item_to_rdf")  {"type: #{object.to_ntriples rescue 'malformed rdf'}"}
+            # log_debug("item_to_rdf")  {"type: #{object.to_ntriples rescue 'malformed rdf'}"}
             yield RDF::Statement(subject, RDF.type, object, graph_name: graph_name, quoted: quoted)
           end
         when '@graph'
@@ -109,12 +109,12 @@ module JSON::LD
           raise "Huh?" unless values.is_a?(Hash)
           values.each do |prop, vv|
             predicate = as_resource(prop)
-            #log_debug("item_to_rdf")  {"@reverse predicate: #{predicate.to_ntriples rescue 'malformed rdf'}"}
+            # log_debug("item_to_rdf")  {"@reverse predicate: #{predicate.to_ntriples rescue 'malformed rdf'}"}
             # For each item in values
             vv.each do |v|
               # Item is a node definition. Generate object as the result of the Object Converstion algorithm passing item.
               object = item_to_rdf(v, graph_name: graph_name, &block)
-              #log_debug("item_to_rdf")  {"subject: #{object.to_ntriples rescue 'malformed rdf'}"}
+              # log_debug("item_to_rdf")  {"subject: #{object.to_ntriples rescue 'malformed rdf'}"}
               # yield subject, prediate, and literal to results.
               yield RDF::Statement(object, predicate, subject, graph_name: graph_name, quoted: quoted)
             end
@@ -129,12 +129,12 @@ module JSON::LD
           # Otherwise, property is an IRI or Blank Node identifier
           # Initialize predicate from  property as an IRI or Blank node
           predicate = as_resource(property)
-          #log_debug("item_to_rdf")  {"predicate: #{predicate.to_ntriples rescue 'malformed rdf'}"}
+          # log_debug("item_to_rdf")  {"predicate: #{predicate.to_ntriples rescue 'malformed rdf'}"}
 
           # For each item in values
           values.each do |v|
             if list?(v)
-              #log_debug("item_to_rdf")  {"list: #{v.inspect}"}
+              # log_debug("item_to_rdf")  {"list: #{v.inspect}"}
               # If item is a list object, initialize list_results as an empty array, and object to the result of the List Conversion algorithm, passing the value associated with the @list key from item and list_results.
               object = parse_list(v['@list'], graph_name: graph_name, &block)
 
@@ -143,7 +143,7 @@ module JSON::LD
             else
               # Otherwise, item is a value object or a node definition. Generate object as the result of the Object Converstion algorithm passing item.
               object = item_to_rdf(v, graph_name: graph_name, &block)
-              #log_debug("item_to_rdf")  {"object: #{object.to_ntriples rescue 'malformed rdf'}"}
+              # log_debug("item_to_rdf")  {"object: #{object.to_ntriples rescue 'malformed rdf'}"}
               # yield subject, prediate, and literal to results.
               yield RDF::Statement(subject, predicate, object, graph_name: graph_name, quoted: quoted)
             end
@@ -164,7 +164,7 @@ module JSON::LD
     # @return [Array<RDF::Statement>]
     #   Statements for each item in the list
     def parse_list(list, graph_name: nil, &block)
-      #log_debug('parse_list') {"list: #{list.inspect}"}
+      # log_debug('parse_list') {"list: #{list.inspect}"}
 
       last = list.pop
       result = first_bnode = last ? node : RDF.nil

--- a/lib/json/ld/writer.rb
+++ b/lib/json/ld/writer.rb
@@ -298,7 +298,7 @@ module JSON::LD
         stream_epilogue
       else
 
-        log_debug("writer") { "serialize #{@repo.count} statements, #{@options.inspect}"}
+        # log_debug("writer") { "serialize #{@repo.count} statements, #{@options.inspect}"}
         result = API.fromRdf(@repo, **@options.merge(serializer: nil))
 
         # Some options may be indicated from accept parameters
@@ -326,11 +326,11 @@ module JSON::LD
 
         if frame = @options[:frame]
           # Perform framing, if given a frame
-          log_debug("writer") { "frame result"}
+          # log_debug("writer") { "frame result"}
           result = API.frame(result, frame, **@options.merge(serializer: nil))
         elsif context
           # Perform compaction, if we have a context
-          log_debug("writer") { "compact result"}
+          # log_debug("writer") { "compact result"}
           result = API.compact(result, context,  **@options.merge(serializer: nil))
         end
 


### PR DESCRIPTION
Hello @gkellogg,

While investigating some memory issues I discovered that the `log_debug` calls generate a lot of objects. Half of them were already commented so this PR comments all the others. 

I did a small benchmark with [memory_profiler](https://github.com/SamSaffron/memory_profiler):

```
allocated memory by gem (current)
-------------------------------------------------------
  48.30 MB  json-ld
  41.03 MB  rdf-ac80b2f2b82e

allocated memory by gem (with all log_debug commented)
-------------------------------------------------------
  43.33 MB  json-ld (- 10%)
  15.79 MB  rdf-ac80b2f2b82e (- 42%)
```

The 3 lines that stores a lot of objects:

*  9.12 MB  rdf/util/logger.rb:181
*  7.97 MB  rdf/util/logger.rb:224
*  6.98 MB  rdf/util/logger.rb:180

This is partly because the RDF utils functions ` logger_debug` / ` logger_common` use splat operators which is quite costly, so I think the PR provide the best ROI.