### PR TITLE
Canonicalize and dedup URLs in to_rb

### DIFF
--- a/lib/json/ld/context.rb
+++ b/lib/json/ld/context.rb
@@ -1724,6 +1724,16 @@ module JSON
       # @return [String]
       def to_rb(*aliases)
         canon_base = RDF::URI(context_base).canonicalize
+        canon_base.scheme = 'http' if canon_base.scheme == 'https'
+
+        aliases = aliases.map do |url|
+          url = RDF::URI(url).canonicalize
+          url.scheme = 'http' if url.scheme == 'https'
+          url.to_s
+        end.uniq
+
+        aliases.delete(canon_base.to_s)
+
         defn = []
 
         defn << "base: #{base.to_s.inspect}" if base


### PR DESCRIPTION
JSON::LD::Context#parse will only [look in the PRELOADED hash](https://github.com/ruby-rdf/json-ld/blob/develop/lib/json/ld/context.rb#L306) with a fully canonicalized URL including replacing https with http. This means that any preloads or aliases under non-canonicalized names won't work and can't be used and will just waste memory.

This commit fully canonicalizes both the base and alias URLs (including changing https to http) and removes any duplicates.

I considered adding error checking or canonicalization in `add_preloaded` and `alias_preloaded` as well, but I'll propose that separately as compatibility is tricky.

See also https://github.com/ruby-rdf/json-ld-preloaded/pull/7 where this is applied, and it ends up removing all aliases (they were unnecessary) and fixing a preload which previously was not working at all (attempting to use it would make the HTTP request).