### PR TITLE
Replace `multi_json` and `oj` gems with standard Ruby `json` gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ This gem also implements an optimized streaming writer used for generating JSON-
 
 The order of triples retrieved from the `RDF::Enumerable` dataset determines the way that JSON-LD node objects are written; for best results, statements should be ordered by _graph name_, _subject_, _predicate_ and _object_.
 
-### MultiJson parser
-The [MultiJson](https://rubygems.org/gems/multi_json) gem is used for parsing and serializing JSON; this defaults to the native JSON parser/serializer, but will use a more performant parser if one is available. A specific parser can be specified by adding the `:adapter` option to any API call. Additionally, a custom serialilzer may be specified by passing the `:serializer` option to {JSON::LD::Writer} or methods of {JSON::LD::API}. See [MultiJson](https://rubygems.org/gems/multi_json) for more information.
+### JSON parser
+The standard Ruby `json` gem is used for parsing and serializing JSON. A custom serializer may be specified by passing the `:serializer` option to {JSON::LD::Writer} or methods of {JSON::LD::API}.
 
 ### JSON-LD-star (RDFStar)
 

--- a/json-ld.gemspec
+++ b/json-ld.gemspec
@@ -34,13 +34,12 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency     'htmlentities', '~> 4.3'
   gem.add_runtime_dependency     'json-canonicalization', '~> 1.0'
   gem.add_runtime_dependency     'link_header', '~> 0.0', '>= 0.0.8'
-  gem.add_runtime_dependency     'multi_json',      '~> 1.15'
+  gem.add_runtime_dependency     'json',            '~> 2.19'
   gem.add_runtime_dependency     "rack",            '>= 2.2', '< 4'
   gem.add_runtime_dependency     'rdf',             '~> 3.3'
   gem.add_runtime_dependency     'rexml',           '~> 3.4'
   gem.add_development_dependency 'getoptlong',      '~> 0.2'
   gem.add_development_dependency 'jsonlint',        '~> 0.4'  unless is_java
-  gem.add_development_dependency 'oj',              '~> 3.15' unless is_java
   gem.add_development_dependency 'rack-test',       '~> 2.1'
   gem.add_development_dependency 'rdf-isomorphic',  '~> 3.3'
   gem.add_development_dependency 'rdf-spec',        '~> 3.3'

--- a/lib/json/ld.rb
+++ b/lib/json/ld.rb
@@ -2,7 +2,6 @@
 
 $LOAD_PATH.unshift(File.expand_path('ld', __dir__))
 require 'rdf' # @see https://rubygems.org/gems/rdf
-require 'multi_json'
 require 'set'
 
 module JSON
@@ -46,8 +45,6 @@ module JSON
     # Default context when compacting without one being specified
     DEFAULT_CONTEXT = 'http://schema.org'
 
-    # Acceptable MultiJson adapters
-    MUTLI_JSON_ADAPTERS = %i[oj json_gem json_pure ok_json yajl nsjsonseerialization]
 
     KEYWORDS = Set.new(%w[
                          @annotation

--- a/lib/json/ld/api.rb
+++ b/lib/json/ld/api.rb
@@ -69,7 +69,6 @@ module JSON
       # @param [String, #read, Hash, Array, JSON::LD::Context] context
       #   An external context to use additionally to the context embedded in input when expanding the input.
       # @param  [Hash{Symbol => Object}] options
-      # @option options [Symbol] :adapter used with MultiJson
       # @option options [RDF::URI, String, #to_s] :base
       #   The Base IRI to use when expanding the document. This overrides the value of `input` if it is a _IRI_. If not specified and `input` is not an _IRI_, the base IRI defaults to the current document IRI if in a browser context, or the empty string if there is no document context. If not specified, and a base IRI is found from `input`, options[:base] will be modified with this value.
       # @option options [Boolean] :compactArrays (true)
@@ -135,8 +134,7 @@ module JSON
 
           case remote_doc.document
           when String
-            mj_opts = options.keep_if { |k, v| k != :adapter || MUTLI_JSON_ADAPTERS.include?(v) }
-            MultiJson.load(remote_doc.document, **mj_opts)
+            JSON.parse(remote_doc.document)
           else
             # Already parsed
             remote_doc.document
@@ -408,8 +406,7 @@ module JSON
             requestProfile: 'http://www.w3.org/ns/json-ld#frame',
                                           **options)
           if remote_doc.document.is_a?(String)
-            mj_opts = options.keep_if { |k, v| k != :adapter || MUTLI_JSON_ADAPTERS.include?(v) }
-            MultiJson.load(remote_doc.document, **mj_opts)
+            JSON.parse(remote_doc.document)
           else
             remote_doc.document
           end
@@ -702,8 +699,7 @@ module JSON
               end
             else
               validate_input(remote_doc.document, url: remote_doc.documentUrl) if validate
-              mj_opts = options.keep_if { |k, v| k != :adapter || MUTLI_JSON_ADAPTERS.include?(v) }
-              MultiJson.load(remote_doc.document, **mj_opts)
+              JSON.parse(remote_doc.document)
             end
           end
 
@@ -714,7 +710,7 @@ module JSON
 
           block_given? ? yield(remote_doc) : remote_doc
         end
-      rescue IOError, MultiJson::ParseError => e
+      rescue IOError, JSON::ParserError => e
         raise JSON::LD::JsonLdError::LoadingDocumentFailed, e.message
       end
 
@@ -767,8 +763,7 @@ module JSON
       SCRIPT_LOADERS = {
         'application/ld+json' => ->(content, url:, **options) do
             validate_input(content, url: url) if options[:validate]
-            mj_opts = options.keep_if { |k, v| k != :adapter || MUTLI_JSON_ADAPTERS.include?(v) }
-            MultiJson.load(content, **mj_opts)
+            JSON.parse(content)
           end
       }
 
@@ -882,14 +877,14 @@ module JSON
           content = element.inner_html
           SCRIPT_LOADERS[script_type].call(content, url: url, **options)
         end
-      rescue MultiJson::ParseError => e
+      rescue JSON::ParserError => e
         raise JSON::LD::JsonLdError::InvalidScriptElement, e.message
       end
 
       ##
       # The default serializer for serialzing Ruby Objects to JSON.
       #
-      # Defaults to `MultiJson.dump`
+      # Defaults to `JSON.generate`
       #
       # @param [Object] object
       # @param [Array<Object>] args
@@ -899,7 +894,7 @@ module JSON
       # @option options [Object] :serializer_opts (JSON_STATE)
       def self.serializer(object, *_args, **options)
         serializer_opts = options.fetch(:serializer_opts, JSON_STATE)
-        MultiJson.dump(object, serializer_opts)
+        JSON.generate(object, serializer_opts)
       end
 
       ##

--- a/lib/json/ld/context.rb
+++ b/lib/json/ld/context.rb
@@ -1817,7 +1817,7 @@ module JSON
         io.rewind
         remote_doc = API.loadRemoteDocument(io, **options)
         if remote_doc.document.is_a?(String)
-          MultiJson.load(remote_doc.document)
+          JSON.parse(remote_doc.document)
         else
           remote_doc.document
         end

--- a/lib/json/ld/from_rdf.rb
+++ b/lib/json/ld/from_rdf.rb
@@ -234,7 +234,12 @@ module JSON
             end
             res['@direction'] = dir
           elsif useNativeTypes && RDF_LITERAL_NATIVE_TYPES.include?(resource.datatype) && resource.valid?
-            res['@value'] = resource.object
+            if resource.datatype == RDF::XSD.double && (resource.object.is_a?(Numeric) && (resource.object.infinite? || resource.object.nan?))
+              res['@type'] = resource.datatype.to_s
+              res['@value'] = resource.to_s
+            else
+              res['@value'] = resource.object
+            end
           else
             resource.canonicalize! if resource.valid? && resource.datatype == RDF::XSD.double
             if resource.datatype?

--- a/lib/json/ld/streaming_reader.rb
+++ b/lib/json/ld/streaming_reader.rb
@@ -31,8 +31,7 @@ module JSON
         rename_bnodes = @options.fetch(:rename_bnodes, true)
         # FIXME: document loader doesn't stream
         @base = RDF::URI(@options[:base] || base_uri)
-        mj_opts = @options.keep_if { |k, v| k != :adapter || MUTLI_JSON_ADAPTERS.include?(v) }
-        value = MultiJson.load(@doc, mj_opts)
+        value = JSON.parse(@doc)
         context_ref = @options[:expandContext]
         # context_ref = @options.fetch(:expandContext, remote_doc.contextUrl)
         context = Context.parse(context_ref, **@options)

--- a/lib/json/ld/streaming_writer.rb
+++ b/lib/json/ld/streaming_writer.rb
@@ -61,7 +61,7 @@ module JSON
           pd << if statement.object.resource?
             { '@id' => statement.object.to_s }
           elsif statement.object.datatype == RDF_JSON
-            { "@value" => MultiJson.load(statement.object.to_s), "@type" => "@json" }
+            { "@value" => JSON.parse(statement.object.to_s), "@type" => "@json" }
           else
             lit = { "@value" => statement.object.to_s }
             lit["@type"] = statement.object.datatype.to_s if statement.object.datatype?

--- a/script/tc
+++ b/script/tc
@@ -13,8 +13,6 @@ require 'getoptlong'
 ASSERTOR = "http://greggkellogg.net/foaf#me"
 RUN_TIME = Time.now
 
-MultiJson.use(:json_gem) # because of differences in parsing with OJ
-
 def earl_preamble(options)
   options[:output].write File.read(File.expand_path("../../etc/doap.ttl", __FILE__))
   options[:output].puts %(
@@ -85,7 +83,6 @@ def run_tc(man, tc, options)
       expected = JSON.load(tc.expect) if tc.evaluationTest? && tc.positiveTest?
       compare_results(tc, output, expected)
     when 'jld:ExpandTest'
-      # MultiJson use OJ, by default, which doesn't handle native numbers the same as the JSON gem.
       output = JSON::LD::API.expand(tc.input_loc, validate: true, **tc.options)
       expected = JSON.load(tc.expect) if tc.evaluationTest? && tc.positiveTest?
       compare_results(tc, output, expected)

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -48,92 +48,87 @@ describe JSON::LD::API do
   end
 
   context "Test Files" do
-    %i[oj json_gem ok_json yajl].each do |adapter|
-      context "with MultiJson adapter #{adapter.inspect}" do
-        Dir.glob(File.expand_path(File.join(File.dirname(__FILE__), 'test-files/*-input.*'))) do |filename|
-          test = File.basename(filename).sub(/-input\..*$/, '')
-          frame = filename.sub(/-input\..*$/, '-frame.jsonld')
-          framed = filename.sub(/-input\..*$/, '-framed.jsonld')
-          compacted = filename.sub(/-input\..*$/, '-compacted.jsonld')
-          context = filename.sub(/-input\..*$/, '-context.jsonld')
-          expanded = filename.sub(/-input\..*$/, '-expanded.jsonld')
-          ttl = filename.sub(/-input\..*$/, '-rdf.ttl')
+    Dir.glob(File.expand_path(File.join(File.dirname(__FILE__), 'test-files/*-input.*'))) do |filename|
+      test = File.basename(filename).sub(/-input\..*$/, '')
+      frame = filename.sub(/-input\..*$/, '-frame.jsonld')
+      framed = filename.sub(/-input\..*$/, '-framed.jsonld')
+      compacted = filename.sub(/-input\..*$/, '-compacted.jsonld')
+      context = filename.sub(/-input\..*$/, '-context.jsonld')
+      expanded = filename.sub(/-input\..*$/, '-expanded.jsonld')
+      ttl = filename.sub(/-input\..*$/, '-rdf.ttl')
 
-          context test,
-            skip: ("Not supported in JRuby" if RUBY_ENGINE == "jruby" && %w[oj yajl].include?(adapter.to_s)) do
-            around do |example|
-              @file = File.open(filename)
-              case filename
-              when /.jsonld$/
-                @file.define_singleton_method(:content_type) { 'application/ld+json' }
-              end
-              if context
-                @ctx_io = File.open(context)
-                case context
-                when /.jsonld$/
-                  @ctx_io.define_singleton_method(:content_type) { 'application/ld+json' }
-                end
-              end
-              example.run
-              @file.close
-              @ctx_io&.close
+      context test do
+        around do |example|
+          @file = File.open(filename)
+          case filename
+          when /.jsonld$/
+            @file.define_singleton_method(:content_type) { 'application/ld+json' }
+          end
+          if context
+            @ctx_io = File.open(context)
+            case context
+            when /.jsonld$/
+              @ctx_io.define_singleton_method(:content_type) { 'application/ld+json' }
             end
+          end
+          example.run
+          @file.close
+          @ctx_io&.close
+        end
 
-            if File.exist?(expanded)
-              it "expands" do
-                options = { logger: logger, adapter: adapter }
-                options[:expandContext] = @ctx_io if context
-                jld = described_class.expand(@file, **options)
-                expect(jld).to produce_jsonld(JSON.parse(File.read(expanded)), logger)
-              end
+        if File.exist?(expanded)
+          it "expands" do
+            options = { logger: logger }
+            options[:expandContext] = @ctx_io if context
+            jld = described_class.expand(@file, **options)
+            expect(jld).to produce_jsonld(JSON.parse(File.read(expanded)), logger)
+          end
 
-              it "expands with serializer" do
-                options = { logger: logger, adapter: adapter }
-                options[:expandContext] = @ctx_io if context
-                jld = described_class.expand(@file, serializer: described_class.method(:serializer), **options)
-                expect(jld).to be_a(String)
-                expect(JSON.parse(jld)).to produce_jsonld(JSON.parse(File.read(expanded)), logger)
-              end
+          it "expands with serializer" do
+            options = { logger: logger }
+            options[:expandContext] = @ctx_io if context
+            jld = described_class.expand(@file, serializer: described_class.method(:serializer), **options)
+            expect(jld).to be_a(String)
+            expect(JSON.parse(jld)).to produce_jsonld(JSON.parse(File.read(expanded)), logger)
+          end
+        end
+
+        if File.exist?(compacted) && File.exist?(context)
+          it "compacts" do
+            jld = described_class.compact(@file, @ctx_io, logger: logger)
+            expect(jld).to produce_jsonld(JSON.parse(File.read(compacted)), logger)
+          end
+
+          it "compacts with serializer" do
+            jld = described_class.compact(@file, @ctx_io, serializer: described_class.method(:serializer),
+              logger: logger)
+            expect(jld).to be_a(String)
+            expect(JSON.parse(jld)).to produce_jsonld(JSON.parse(File.read(compacted)), logger)
+          end
+        end
+
+        if File.exist?(framed) && File.exist?(frame)
+          it "frames" do
+            File.open(frame) do |frame_io|
+              jld = described_class.frame(@file, frame_io, logger: logger)
+              expect(jld).to produce_jsonld(JSON.parse(File.read(framed)), logger)
             end
+          end
 
-            if File.exist?(compacted) && File.exist?(context)
-              it "compacts" do
-                jld = described_class.compact(@file, @ctx_io, adapter: adapter, logger: logger)
-                expect(jld).to produce_jsonld(JSON.parse(File.read(compacted)), logger)
-              end
-
-              it "compacts with serializer" do
-                jld = described_class.compact(@file, @ctx_io, serializer: described_class.method(:serializer),
-                  adapter: adapter, logger: logger)
-                expect(jld).to be_a(String)
-                expect(JSON.parse(jld)).to produce_jsonld(JSON.parse(File.read(compacted)), logger)
-              end
+          it "frames with serializer" do
+            File.open(frame) do |frame_io|
+              jld = described_class.frame(@file, frame_io, serializer: described_class.method(:serializer),
+                logger: logger)
+              expect(jld).to be_a(String)
+              expect(JSON.parse(jld)).to produce_jsonld(JSON.parse(File.read(framed)), logger)
             end
+          end
+        end
 
-            if File.exist?(framed) && File.exist?(frame)
-              it "frames" do
-                File.open(frame) do |frame_io|
-                  jld = described_class.frame(@file, frame_io, adapter: adapter, logger: logger)
-                  expect(jld).to produce_jsonld(JSON.parse(File.read(framed)), logger)
-                end
-              end
-
-              it "frames with serializer" do
-                File.open(frame) do |frame_io|
-                  jld = described_class.frame(@file, frame_io, serializer: described_class.method(:serializer),
-                    adapter: adapter, logger: logger)
-                  expect(jld).to be_a(String)
-                  expect(JSON.parse(jld)).to produce_jsonld(JSON.parse(File.read(framed)), logger)
-                end
-              end
-            end
-
-            if File.exist?(ttl)
-              it "toRdf" do
-                expect(RDF::Repository.load(filename, format: :jsonld, adapter: adapter,
-                  logger: logger)).to be_equivalent_graph(RDF::Repository.load(ttl), logger: logger)
-              end
-            end
+        if File.exist?(ttl)
+          it "toRdf" do
+            expect(RDF::Repository.load(filename, format: :jsonld,
+              logger: logger)).to be_equivalent_graph(RDF::Repository.load(ttl), logger: logger)
           end
         end
       end

--- a/spec/suite_expand_spec.rb
+++ b/spec/suite_expand_spec.rb
@@ -7,8 +7,7 @@ unless ENV['CI']
       m = Fixtures::SuiteTest::Manifest.open("#{Fixtures::SuiteTest::SUITE}expand-manifest.jsonld")
       describe m.name do
         m.entries.each do |t|
-          # MultiJson use OJ, by default, which doesn't handle native numbers the same as the JSON gem.
-          t.options[:adapter] = :json_gem if %w[#tjs12].include?(t.property('@id'))
+
           specify "#{t.property('@id')}: #{t.name} unordered#{' (negative test)' unless t.positiveTest?}" do
             t.options[:ordered] = false
             if %w[#t0068].include?(t.property('@id'))


### PR DESCRIPTION
### Description

Proposing we remove the `multi_json` and `oj` gems in favour of the standard Ruby `json` gem as it's now as fast or faster in the majority of cases compared to `oj`. Additionally allows us to simplify code quite a bit too. :sparkles: 

Related efforts
- https://github.com/opensearch-project/opensearch-ruby/pull/290
- https://github.com/mastodon/mastodon/pull/37752

### Implementation

Generally it's a pretty simple swap and cleanup. That said, the one quirk comes from the fact that `oj` could apparently handle non-finite doubles such as infinity. As the Standard JSON (RFC 8259) does not support non-finite doubles such as `NaN`, `Infinity`, and `-Infinity` as numeric values, the `JSON` gem can raise a `JSON::GeneratorError` when passed such values for generation. Thus, I'm proposing we use string representation + type for such values. Open to opinions.

Probably worth reviewing with whitespace disabled re: the indentation changes in `spec/api_spec.rb`. Link below.

https://github.com/ruby-rdf/json-ld/pull/64/changes?w=1

### Notes

Apparently [v1.20.0](https://github.com/sferik/multi_json/blob/9ae5a429e519fb70440833d8b8968a2123da9098/CHANGELOG.md#1200) of `multi_json` dropped support for `ok_json`. :man_shrugging: :fire: