### PR TITLE
Add CI testing against Ruby 3.4 and 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.3, ruby-head, jruby]
+        ruby: ['3.3', '3.4', '4.0', ruby-head, jruby]
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.3]
+        ruby: ['3.3', '3.4', '4.0']
     steps:
       - name: Clone repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Proposing we add CI testing against both Ruby `3.4` and `4.0` given `ruby-head` is now Ruby 4.1. Note, I wasn't sure what to do with the `wintests` section so I updated it the same but can revert if desired.