### PR TITLE
Drop support for `ok_json` and `json_pure` as `multi_json` has done

### DIFF
--- a/lib/json/ld.rb
+++ b/lib/json/ld.rb
@@ -47,7 +47,7 @@ module JSON
     DEFAULT_CONTEXT = 'http://schema.org'
 
     # Acceptable MultiJson adapters
-    MUTLI_JSON_ADAPTERS = %i[oj json_gem json_pure ok_json yajl nsjsonseerialization]
+    MUTLI_JSON_ADAPTERS = %i[oj json_gem yajl nsjsonseerialization]
 
     KEYWORDS = Set.new(%w[
                          @annotation

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -48,7 +48,7 @@ describe JSON::LD::API do
   end
 
   context "Test Files" do
-    %i[oj json_gem ok_json yajl].each do |adapter|
+    %i[oj json_gem yajl].each do |adapter|
       context "with MultiJson adapter #{adapter.inspect}" do
         Dir.glob(File.expand_path(File.join(File.dirname(__FILE__), 'test-files/*-input.*'))) do |filename|
           test = File.basename(filename).sub(/-input\..*$/, '')


### PR DESCRIPTION
Trying to bring this gem up-to-date and get CI passing I came across the fact that modern `multi_json` has removed support for `ok_json` (dropped) and `json_pure` (aliased to `json_gem`). Thus, short of us removing `multi_json`, which I'm also proposing in https://github.com/ruby-rdf/json-ld/pull/64, we need to drop those two adapters as a preliminary fix.

- `ok_json` | https://github.com/sferik/multi_json/blob/9ae5a429e519fb70440833d8b8968a2123da9098/CHANGELOG.md#1200
- `json_pure` | https://github.com/sferik/multi_json/blob/9ae5a429e519fb70440833d8b8968a2123da9098/CHANGELOG.md#1160