### PR TITLE
Drop support for EOL rubies i.e. those older than 3.3.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.0', 3.1, 3.2, 3.3, ruby-head, jruby]
+        ruby: [3.3, ruby-head, jruby]
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -42,11 +42,10 @@ jobs:
     runs-on: windows-latest
     env:
       CI: true
-      ALLOW_FAILURES: ${{ matrix.ruby == '3.2' || matrix.ruby == 'jruby' }}
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.1, 3.2]
+        ruby: [3.3]
     steps:
       - name: Clone repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Proposing we drop support for EOL rubies i.e. those older than 3.3.x. ([source](https://endoflife.date/ruby))

<img width="1524" height="888" alt="Screenshot From 2026-06-19 23-38-07" src="https://github.com/user-attachments/assets/281a920a-49d5-4d8b-bdf0-0e4cf206c330" />